### PR TITLE
Implement Cache Read + Hook Proxy up to CacheController+Datastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ google-services.json
 
 # automatedtests results
 automatedtests/automated_test_results/**
+
+# Test data
+*.raw

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MuxVideoMedia3"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".examples.BasicPlayerActivity"

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -24,7 +24,7 @@ class MuxPlayer private constructor(
   private val exoPlayer: ExoPlayer,
   private val muxDataKey: String?,
   private val logger: Logger,
-  private val muxCacheEnabled: Boolean = false,
+  private val muxCacheEnabled: Boolean = true,
   context: Context,
   initialCustomerData: CustomerData,
   network: INetworkRequest? = null,

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -37,6 +37,7 @@ class MuxPlayer private constructor(
   override fun release() {
     // good to release muxStats first, so it doesn't call to the player after release
     muxStats?.release()
+    muxStats = null
     // exoPlayer can handle multiple calls itself, not our deal
     exoPlayer.release()
 

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -24,6 +24,7 @@ class MuxPlayer private constructor(
   private val exoPlayer: ExoPlayer,
   private val muxDataKey: String?,
   private val logger: Logger,
+  private val muxCacheEnabled: Boolean = false,
   context: Context,
   initialCustomerData: CustomerData,
   network: INetworkRequest? = null,
@@ -31,14 +32,29 @@ class MuxPlayer private constructor(
 ) : ExoPlayer by exoPlayer {
 
   private var muxStats: MuxStatsSdkMedia3<ExoPlayer>? = null
+  private var released: Boolean = false
 
   override fun release() {
+    // good to release muxStats first, so it doesn't call to the player after release
     muxStats?.release()
+    // exoPlayer can handle multiple calls itself, not our deal
     exoPlayer.release()
+
+    // our own cleanup should only happen once
+    if (!released) {
+      if (muxCacheEnabled) {
+        CacheController.onPlayerReleased()
+      }
+    }
+
+    released = true
   }
 
   init {
-    CacheController.setup(context, null)
+    if (muxCacheEnabled) {
+      CacheController.setup(context, null)
+      CacheController.onPlayerCreated()
+    }
 
     // listen internally before Mux Data gets events, in case we need to handle something before
     // the data SDK sees (like media metadata for new streams during a MediaItem transition, etc)

--- a/library/src/main/java/com/mux/player/cacheing/CDNConnection.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CDNConnection.kt
@@ -116,19 +116,16 @@ class CDNConnection(val playerConnection: PlayerConnection, val parent:ProxyServ
     ) {
       val readBuf = ByteArray(READ_SIZE)
 
-      try {
-        while (true) {
-          val readBytes = externalInput.read(readBuf)
-          if (readBytes == -1) {
-            // done
-            break
-          } else {
-            writeHandle.write(readBuf, 0, readBytes)
-          }
+      while (true) {
+        val readBytes = externalInput.read(readBuf)
+        if (readBytes == -1) {
+          // done
+          break
+        } else {
+          writeHandle.write(readBuf, 0, readBytes)
         }
-      } finally {
-        writeHandle.finishedWriting()
       }
+      writeHandle.finishedWriting()
     }
 
 //    private fun copyToPlayer(httpParser:HttpParser) {

--- a/library/src/main/java/com/mux/player/cacheing/CDNConnection.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CDNConnection.kt
@@ -26,7 +26,7 @@ class CDNConnection(val playerConnection: PlayerConnection, val parent:ProxyServ
     private var outputStream: OutputStream? = null
     private var socket: Socket? = null
     private var contextType = MediaContextType.UNKNOWN
-    private var outputWriter:PrintWriter? = null
+//    private var outputWriter:PrintWriter? = null
     private var cdnUrl:URL? = null
 
 
@@ -45,11 +45,11 @@ class CDNConnection(val playerConnection: PlayerConnection, val parent:ProxyServ
         }
         inputStream = socket!!.getInputStream()
         outputStream = socket!!.getOutputStream()
-        outputWriter = PrintWriter(
-            OutputStreamWriter(
-                outputStream!!, StandardCharsets.US_ASCII
-            ), true
-        )
+//        outputWriter = PrintWriter(
+//            OutputStreamWriter(
+//                outputStream!!, StandardCharsets.US_ASCII
+//            ), true
+//        )
     }
 
     fun send(httpParser:HttpParser) {
@@ -57,12 +57,12 @@ class CDNConnection(val playerConnection: PlayerConnection, val parent:ProxyServ
         httpParser.serializeRequest(outputStream!!)
     }
 
-    fun send(chunk:String) {
-        if (chunk.length > 0) {
-            outputWriter!!.write(chunk)
-            outputWriter!!.flush()
-        }
-    }
+//    fun send(chunk:String) {
+//        if (chunk.length > 0) {
+//            outputWriter!!.write(chunk)
+//            outputWriter!!.flush()
+//        }
+//    }
 
     fun processResponse() {
         val httpParser = HttpParser(socket!!.getInputStream())
@@ -73,8 +73,8 @@ class CDNConnection(val playerConnection: PlayerConnection, val parent:ProxyServ
 
       val writeHandle = CacheController.downloadStarted(
         requestUrl = cdnUrl!!.toString(),
-        responseHeaders = httpParser.headers.mapValues{ listOf(it.value) },
-        playerOutputStream = playerConnection.getStreamToPlayer()
+        responseHeaders = httpParser.headers.mapValues { listOf(it.value) },
+        playerOutputStream = playerConnection.getStreamToPlayer(),
       )
 
         if (httpParser.statusCode in 300..399) {

--- a/library/src/main/java/com/mux/player/cacheing/CDNConnection.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CDNConnection.kt
@@ -169,15 +169,27 @@ class CDNConnection(val playerConnection: PlayerConnection, val parent: ProxySer
     val contentTypeHeader = httpParser.getHeader("Content-Type")
     if (contentTypeHeader.isEmpty()) {
       // TODO read first line of body and see if it is #EXTM3U
-    } else if (contentTypeHeader.equals("application/vnd.apple.mpegurl", true)
-      || contentTypeHeader.equals("audio/mpegurl", true)
-      || contentTypeHeader.equals("application/mpegurl", true)
-      || contentTypeHeader.equals("application/x-mpegurl", true)
-      || contentTypeHeader.equals("audio/x-mpegurl", true)
-    ) {
+    } else if (isContentTypePlaylist(contentTypeHeader)) {
       contextType = MediaContextType.MANIFEST
     } else {
       contextType = MediaContextType.SEGMENT
     }
   }
+}
+
+@JvmSynthetic
+internal fun isContentTypeSegment(contentTypeHeader: String?): Boolean {
+ return contentTypeHeader.equals(CacheConstants.MIME_TS, true)
+         || contentTypeHeader.equals(CacheConstants.MIME_M4S, true)
+         || contentTypeHeader.equals(CacheConstants.MIME_M4S_ALT, true)
+}
+
+@JvmSynthetic
+internal fun isContentTypePlaylist(contentTypeHeader: String?): Boolean {
+ return (contentTypeHeader.equals("application/vnd.apple.mpegurl", true)
+         || contentTypeHeader.equals("audio/mpegurl", true)
+         || contentTypeHeader.equals("application/mpegurl", true)
+         || contentTypeHeader.equals("application/x-mpegurl", true)
+         || contentTypeHeader.equals("audio/x-mpegurl", true)
+         )
 }

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -54,12 +54,13 @@ internal object CacheController {
    * resource, like its original URL, response headers, and cache-control directives
    */
   fun tryRead(
-    requestUrl: String
+    requestUrl: String,
   ): ReadHandle? {
     // todo - check for initialization and throw Something
 
     val fileRecord = datastore.readRecord(requestUrl)
-    return if (fileRecord == null || !fileRecord.file.exists()) {
+    // todo readRecord checks for the file?
+    return if (fileRecord == null) {
       null
     } else {
       ReadHandle(
@@ -214,7 +215,8 @@ internal object CacheController {
           val record = FileRecord(
             url = url,
             etag = etag,
-            file = cacheFile,
+            relativePath = cacheFile.path,
+            lastAccessUtcSecs = nowUtc,
             lookupKey = datastore.safeCacheKey(URL(url)),
             downloadedAtUtcSecs = nowUtc,
             cacheMaxAge = maxAge ?: TimeUnit.SECONDS.convert(7, TimeUnit.DAYS),

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -4,9 +4,11 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import com.mux.player.internal.cache.FileRecord
+import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.OutputStream
@@ -66,7 +68,9 @@ internal object CacheController {
       ReadHandle(
         url = requestUrl,
         file = fileRecord,
-        fileInput = ByteArrayInputStream(ByteArray(5))
+        fileInput = BufferedInputStream(
+          FileInputStream(File(datastore.fileCacheDir(), fileRecord.relativePath))
+        )
       )
     }
   }
@@ -182,7 +186,7 @@ internal object CacheController {
       playerOutputStream.write(data, offset, len)
       fileOutputStream?.write(data, offset, len)
     }
-
+    
     /**
      * Writes the given String's bytes to both the player socket and the file
      */
@@ -190,8 +194,6 @@ internal object CacheController {
       playerOutputStream.write(data.toByteArray(Charsets.US_ASCII))
       fileOutputStream?.write(data.toByteArray(Charsets.US_ASCII))
     }
-
-    // todo - method to call if the proxy encounters an error, closes & deletes temp file
 
     /**
      * Call when you've reached the end of the body input. This closes the streams to the player

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -115,13 +115,15 @@ internal object CacheController {
     responseHeaders: Map<String, List<String>>
   ): Boolean {
     val cacheControlLine = responseHeaders.getCacheControl()
-
     if (cacheControlLine == null) {
       return false
     }
     if (cacheControlLine.contains(RX_NO_STORE)) {
       return false
     }
+
+    // todo - Need to specifically only cache segments. Check content-type first then url
+    
     // todo - additional logic here:
     //  * check disk space against Content-Length?
     //  * check for headers like Age?

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -123,7 +123,7 @@ internal object CacheController {
     }
 
     // todo - Need to specifically only cache segments. Check content-type first then url
-    
+
     // todo - additional logic here:
     //  * check disk space against Content-Length?
     //  * check for headers like Age?

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -64,7 +64,7 @@ internal object CacheController {
    * Call internally when a new MuxPlayer is created, if caching was enabled.
    */
   @JvmSynthetic
-  internal fun maybeOpen() {
+  internal fun onPlayerCreated() {
     val totalPlayersBefore = playersWithCache.getAndIncrement()
     if (totalPlayersBefore == 0) {
       ioScope.launch { datastore.open() }
@@ -77,7 +77,7 @@ internal object CacheController {
    * Try to call only once per player, even if caller calls release() multiple times
    */
   @JvmSynthetic
-  internal fun maybeClose() {
+  internal fun onPlayerReleased() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       closeDatastoreApiN()
     } else {

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -41,6 +41,8 @@ internal object CacheController {
   // Only start it if you incremented from 0, only stop if you decrement from 0
   private var proxyServer: ProxyServer? = null
 
+  const val TAG = "CacheController"
+
   val RX_NO_STORE = Regex("""no-store""")
   val RX_NO_CACHE = Regex("""no-cache""")
   val RX_MAX_AGE = Regex("""max-age=([0-9].*)""")
@@ -68,7 +70,9 @@ internal object CacheController {
    */
   @JvmSynthetic
   internal fun onPlayerCreated() {
+    Log.d(TAG, "onPlayerCreated: called")
     val totalPlayersBefore = playersWithCache.getAndIncrement()
+    Log.d(TAG, "onPlayerCreated: had $totalPlayersBefore players")
     if (totalPlayersBefore == 0) {
       ioScope.launch { datastore.open() }
       proxyServer = ProxyServer()
@@ -92,6 +96,7 @@ internal object CacheController {
   @TargetApi(Build.VERSION_CODES.N)
   private fun closeDatastoreApiN() {
     val totalPlayersNow = playersWithCache.updateAndGet { if (it > 0) it - 1 else it }
+    Log.d(TAG, "closeDatastoreApiN: now have $totalPlayersNow players")
     if (totalPlayersNow == 0) {
       ioScope.launch { datastore.close() }
     }
@@ -99,6 +104,7 @@ internal object CacheController {
 
   private fun closeDatastoreLegacy() {
     val totalPlayersNow = playersWithCache.decrementAndGet()
+    Log.d(TAG, "closeDatastoreLegacy: now have $totalPlayersNow players")
     if (totalPlayersNow == 0) {
       ioScope.launch { datastore.close() }
     }

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -37,6 +37,9 @@ internal object CacheController {
 
   private val playersWithCache = AtomicInteger(0)
   private val ioScope = CoroutineScope(Dispatchers.IO)
+  // access gated via playersWithCache.
+  // Only start it if you incremented from 0, only stop if you decrement from 0
+  private var proxyServer: ProxyServer? = null
 
   val RX_NO_STORE = Regex("""no-store""")
   val RX_NO_CACHE = Regex("""no-cache""")
@@ -68,6 +71,7 @@ internal object CacheController {
     val totalPlayersBefore = playersWithCache.getAndIncrement()
     if (totalPlayersBefore == 0) {
       ioScope.launch { datastore.open() }
+      proxyServer = ProxyServer()
     }
   }
 

--- a/library/src/main/java/com/mux/player/cacheing/CacheController.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheController.kt
@@ -175,9 +175,9 @@ internal object CacheController {
     /**
      * Writes the given bytes to both the player socket and the file
      */
-    fun write(data: ByteArray) {
-      playerOutputStream.write(data)
-      fileOutputStream?.write(data)
+    fun write(data: ByteArray, offset: Int, len: Int) {
+      playerOutputStream.write(data, offset, len)
+      fileOutputStream?.write(data, offset, len)
     }
 
     /**

--- a/library/src/main/java/com/mux/player/cacheing/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheDatastore.kt
@@ -32,10 +32,10 @@ internal class CacheDatastore(val context: Context) : Closeable {
 
   companion object {
     private val openTask: AtomicReference<FutureTask<DbHelper>> = AtomicReference(null)
+    val RX_CHUNK_URL =
+      Regex("""^https://[^/]*/v1/chunk/([^/]*)/([^/]*)\.(m4s|ts)""")
   }
 
-  private val RX_CHUNK_URL =
-    Regex("""^https://[^/]*/v1/chunk/([^/]*)/([^/]*)\.(m4s|ts)""")
 
   private val dbHelper: DbHelper get() = awaitDbHelper()
 

--- a/library/src/main/java/com/mux/player/cacheing/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheDatastore.kt
@@ -10,6 +10,7 @@ import android.util.Base64
 import android.util.Log
 import com.mux.player.internal.cache.FileRecord
 import com.mux.player.internal.cache.toContentValues
+import com.mux.player.internal.cache.toFileRecord
 import com.mux.player.oneOf
 import java.io.Closeable
 import java.io.File
@@ -123,8 +124,18 @@ internal class CacheDatastore(val context: Context) : Closeable {
   }
 
   fun readRecord(url: String): FileRecord? {
-    // todo - try to read a record for the given URL, returning it if there's a hit
-    return null
+    val cursor = dbHelper.writableDatabase.query(
+      IndexSchema.FilesTable.name, null,
+      "${IndexSchema.FilesTable.Columns.lookupKey} is ?",
+      arrayOf(safeCacheKey(URL(url))),
+      null, null, null
+    )
+
+    return if (cursor.count > 0 && cursor.moveToFirst()) {
+      cursor.toFileRecord()
+    } else {
+      null
+    }
   }
 
   /**

--- a/library/src/main/java/com/mux/player/cacheing/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/cacheing/CacheDatastore.kt
@@ -124,17 +124,17 @@ internal class CacheDatastore(val context: Context) : Closeable {
   }
 
   fun readRecord(url: String): FileRecord? {
-    val cursor = dbHelper.writableDatabase.query(
+    return dbHelper.writableDatabase.query(
       IndexSchema.FilesTable.name, null,
       "${IndexSchema.FilesTable.Columns.lookupKey} is ?",
       arrayOf(safeCacheKey(URL(url))),
       null, null, null
-    )
-
-    return if (cursor.count > 0 && cursor.moveToFirst()) {
-      cursor.toFileRecord()
-    } else {
-      null
+    ).use { cursor ->
+      if (cursor.count > 0 && cursor.moveToFirst()) {
+        cursor.toFileRecord()
+      } else {
+        null
+      }
     }
   }
 
@@ -216,9 +216,9 @@ internal class CacheDatastore(val context: Context) : Closeable {
     }
   }
 
-  private fun fileTempDir(): File = File(context.cacheDir, CacheConstants.TEMP_FILE_DIR)
-  private fun fileCacheDir(): File = File(context.cacheDir, CacheConstants.CACHE_FILES_DIR)
-  private fun indexDbDir(): File = File(context.filesDirNoBackupCompat, CacheConstants.CACHE_BASE_DIR)
+  fun fileTempDir(): File = File(context.cacheDir, CacheConstants.TEMP_FILE_DIR)
+  fun fileCacheDir(): File = File(context.cacheDir, CacheConstants.CACHE_FILES_DIR)
+  fun indexDbDir(): File = File(context.filesDirNoBackupCompat, CacheConstants.CACHE_BASE_DIR)
 
   /**
    * Creates a new temp file for downloading-into. Temp files go in a special dir that gets cleared

--- a/library/src/main/java/com/mux/player/cacheing/HttpParser.kt
+++ b/library/src/main/java/com/mux/player/cacheing/HttpParser.kt
@@ -8,7 +8,7 @@ import java.lang.StringBuilder
 import java.net.SocketException
 import java.util.Hashtable
 
-class HttpParser(val input:InputStream) {
+class HttpParser(val input: InputStream) {
 
     val TAG:String = "Proxy||HttpParser"
 
@@ -56,7 +56,7 @@ class HttpParser(val input:InputStream) {
         parseBody()
     }
 
-    fun parseResponse() {
+    fun parseResponse(readBody: Boolean = true) {
         var line = reader.readLine()
         responseLine = line
         val statusCodeStr = responseLine.split(" ")[1]
@@ -71,7 +71,9 @@ class HttpParser(val input:InputStream) {
             appendHeaderParameter(line)
             line = reader.readLine()
         }
-        parseBody()
+        if (readBody) {
+          parseBody()
+        }
     }
 
     private fun updateRequestLine() {

--- a/library/src/main/java/com/mux/player/cacheing/PlayerConnection.kt
+++ b/library/src/main/java/com/mux/player/cacheing/PlayerConnection.kt
@@ -58,6 +58,8 @@ class PlayerConnection(val socket: Socket, val parent:ProxyServer) {
             val localUrl = "http://" + cdnHostHeaderValue + httpParser!!.path
             var cdnUrl = parent.decodeUrl(URL(localUrl))
 
+          // todo - read from cache here
+
             var cdnConnection = CDNConnection(this, parent)
             cdnConnection.openConnection(cdnUrl)
 

--- a/library/src/main/java/com/mux/player/cacheing/PlayerConnection.kt
+++ b/library/src/main/java/com/mux/player/cacheing/PlayerConnection.kt
@@ -1,6 +1,7 @@
 package com.mux.player.cacheing
 
 import android.util.Log
+import java.io.OutputStream
 import java.net.Socket
 import java.net.SocketException
 import java.net.URL
@@ -26,15 +27,17 @@ class PlayerConnection(val socket: Socket, val parent:ProxyServer) {
         try {
             httpParser = HttpParser(socket.getInputStream())
             readThread.start()
-            writeThread.start()
+            //writeThread.start()
         } catch (ex:Exception) {
             ex.printStackTrace()
         }
     }
 
-    fun send(chunk:ByteArray) {
-        cdnInputQueue.put(chunk)
-    }
+  fun getStreamToPlayer(): OutputStream = socket.getOutputStream()
+
+//    fun send(chunk:ByteArray) {
+//        cdnInputQueue.put(chunk)
+//    }
 
     fun kill() {
         // TODO: kill all threads
@@ -54,6 +57,7 @@ class PlayerConnection(val socket: Socket, val parent:ProxyServer) {
             }
             val localUrl = "http://" + cdnHostHeaderValue + httpParser!!.path
             var cdnUrl = parent.decodeUrl(URL(localUrl))
+
             var cdnConnection = CDNConnection(this, parent)
             cdnConnection.openConnection(cdnUrl)
 
@@ -73,23 +77,24 @@ class PlayerConnection(val socket: Socket, val parent:ProxyServer) {
     }
 
     private fun write() {
-        val writeHandle = CacheController.downloadStarted(
-            requestUrl = "How to get this",
-            responseHeaders = mapOf(), // todo - real headers
-            socket.getOutputStream()
-        )
-        try {
-            while (running) {
-                val chunk = cdnInputQueue.takeFirst()
-                // todo - how much are we writing here?
-                writeHandle.write(chunk)
-
-                // todo - when is EOF?
-            }
-            // todo - get here somehow.. After we reach the end of the request
-            writeHandle.finishedWriting()
-        } catch(ex:SocketException) {
-            Log.i(TAG, "Player closed the connection")
-        }
+      // todo - write thread not necessary, we are writing from the CDNConnection using the stream
+//        val writeHandle = CacheController.downloadStarted(
+//            requestUrl = "How to get this",
+//            responseHeaders = mapOf(), // todo - real headers
+//            socket.getOutputStream()
+//        )
+//        try {
+//            while (running) {
+//                val chunk = cdnInputQueue.takeFirst()
+//                // todo - how much are we writing here?
+//                writeHandle.write(chunk)
+//
+//                // todo - when is EOF?
+//            }
+//            // todo - get here somehow.. After we reach the end of the request
+//            writeHandle.finishedWriting()
+//        } catch(ex:SocketException) {
+//            Log.i(TAG, "Player closed the connection")
+//        }
     }
 }

--- a/library/src/main/java/com/mux/player/cacheing/PlayerConnection.kt
+++ b/library/src/main/java/com/mux/player/cacheing/PlayerConnection.kt
@@ -59,9 +59,8 @@ class PlayerConnection(val socket: Socket, val parent: ProxyServer) {
 
       // todo - read from cache here
       val readHandle = CacheController.tryRead(cdnUrl.toString())
-
       if (readHandle == null) {
-        var cdnConnection = CDNConnection(this, parent)
+        val cdnConnection = CDNConnection(this, parent)
         cdnConnection.openConnection(cdnUrl)
 
         var hostHeaderValue = cdnUrl.host
@@ -74,7 +73,7 @@ class PlayerConnection(val socket: Socket, val parent: ProxyServer) {
         cdnConnection.send(httpParser!!)
         cdnConnection.processResponse()
       } else {
-        // todo use ReadHandle. Read to getStreamToPlayer
+        readHandle.use { it.readAllInto(getStreamToPlayer()) }
       }
     } catch (ex: Exception) {
       Log.e(TAG, "What happend !!!", ex);

--- a/library/src/main/java/com/mux/player/cacheing/ProxyServer.kt
+++ b/library/src/main/java/com/mux/player/cacheing/ProxyServer.kt
@@ -8,7 +8,7 @@ import java.net.URI
 import java.net.URL
 import java.util.concurrent.LinkedBlockingDeque
 
-class ProxyServer (val port:Int = 5000): Thread() {
+class ProxyServer (val port:Int = CacheConstants.PROXY_PORT): Thread() {
 
     private val TAG = "ProxyServer"
 
@@ -76,6 +76,7 @@ class ProxyServer (val port:Int = 5000): Thread() {
         }
         var cdnPath = url.path.split(hostDetails + "/")[1]
         var resultStr = cdnProtocol + hostSegments[1] + cdnPort + "/" + cdnPath + cdnQuery
+      Log.d(TAG, "Decoded URL for CDN: $resultStr")
         return URL(resultStr)
     }
 

--- a/library/src/main/java/com/mux/player/cacheing/ProxyServer.kt
+++ b/library/src/main/java/com/mux/player/cacheing/ProxyServer.kt
@@ -19,6 +19,7 @@ class ProxyServer (val port:Int = 5000): Thread() {
     private val activeConnections: LinkedBlockingDeque<PlayerConnection> = LinkedBlockingDeque<PlayerConnection>()
 
     init {
+      Log.d(TAG, "Starting server on port $port")
         try {
             socketServer = ServerSocket(port)
         } catch (ex:IOException) {

--- a/library/src/main/java/com/mux/player/internal/cache/FileRecord.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/FileRecord.kt
@@ -1,14 +1,72 @@
 package com.mux.player.internal.cache
 
+import android.content.ContentValues
+import android.database.Cursor
+import com.mux.player.cacheing.IndexSchema
 import java.io.File
+import java.io.IOException
 
 data class FileRecord(
   val url: String,
   val etag: String,
-  val file: File,
+  val relativePath: String,
   val lookupKey: String,
+  val lastAccessUtcSecs: Long,
   val downloadedAtUtcSecs: Long,
   val cacheMaxAge: Long,
   val resourceAge: Long,
   val cacheControl: String,
 )
+
+@JvmSynthetic
+internal fun FileRecord.toContentValues(): ContentValues {
+  val values = ContentValues()
+
+  values.apply {
+    put(IndexSchema.FilesTable.Columns.lookupKey, lookupKey)
+    put(IndexSchema.FilesTable.Columns.etag, etag)
+    put(IndexSchema.FilesTable.Columns.filePath, relativePath)
+    put(IndexSchema.FilesTable.Columns.remoteUrl, url)
+    put(IndexSchema.FilesTable.Columns.downloadedAtUnixTime, downloadedAtUtcSecs)
+    put(IndexSchema.FilesTable.Columns.maxAgeUnixTime, cacheMaxAge)
+    put(IndexSchema.FilesTable.Columns.resourceAgeUnixTime, resourceAge)
+    put(IndexSchema.FilesTable.Columns.cacheControl, cacheControl)
+  }
+
+  return values
+}
+
+@JvmSynthetic
+internal fun Cursor.toFileRecord(): FileRecord {
+  return FileRecord(
+    url = getStringOrThrow(IndexSchema.FilesTable.Columns.remoteUrl),
+    lookupKey = getStringOrThrow(IndexSchema.FilesTable.Columns.lookupKey),
+    lastAccessUtcSecs = getLongOrThrow(IndexSchema.FilesTable.Columns.lastAccessUnixTime),
+    etag = getStringOrThrow(IndexSchema.FilesTable.Columns.etag),
+    relativePath = getStringOrThrow(IndexSchema.FilesTable.Columns.filePath),
+    downloadedAtUtcSecs = getLongOrThrow(IndexSchema.FilesTable.Columns.downloadedAtUnixTime),
+    cacheMaxAge = getLongOrThrow(IndexSchema.FilesTable.Columns.maxAgeUnixTime),
+    resourceAge = getLongOrThrow(IndexSchema.FilesTable.Columns.resourceAgeUnixTime),
+    cacheControl = getStringOrThrow(IndexSchema.FilesTable.Columns.cacheControl)
+  )
+}
+
+@Throws(IOException::class)
+fun Cursor.getStringOrThrow(name: String): String {
+  val idx = getColumnIndex(name)
+  return if (idx >= 0) {
+    getString(idx)
+  } else {
+    throw IOException("Could not find expected column: $name")
+  }
+}
+
+@Throws(IOException::class)
+fun Cursor.getLongOrThrow(name: String): Long {
+  val idx = getColumnIndex(name)
+  return if (idx >= 0) {
+    getLong(idx)
+  } else {
+    throw IOException("Could not find expected column: $name")
+  }
+}

--- a/library/src/main/java/com/mux/player/internal/cache/FileRecord.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/FileRecord.kt
@@ -2,9 +2,11 @@ package com.mux.player.internal.cache
 
 import android.content.ContentValues
 import android.database.Cursor
+import com.mux.player.cacheing.CacheController
 import com.mux.player.cacheing.IndexSchema
-import java.io.File
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 
 data class FileRecord(
   val url: String,
@@ -68,5 +70,19 @@ fun Cursor.getLongOrThrow(name: String): Long {
     getLong(idx)
   } else {
     throw IOException("Could not find expected column: $name")
+  }
+}
+
+@Throws(IOException::class)
+fun InputStream.consumeInto(outputStream: OutputStream, readSize: Int = 32 * 1024) {
+  val buf = ByteArray(CacheController.ReadHandle.READ_SIZE)
+  while (true) {
+    val readBytes = read(buf)
+    if (readBytes == -1) {
+      // done
+      break
+    } else {
+      outputStream.write(buf, 0, readBytes)
+    }
   }
 }

--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -1,6 +1,7 @@
 package com.mux.player.media
 
 import android.net.Uri
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
@@ -25,6 +26,10 @@ class MuxDataSource private constructor(
     override fun createDataSource(): DataSource {
       return MuxDataSource(upstream.createDataSource())
     }
+  }
+
+  companion object {
+    const val TAG = "MuxDataSource"
   }
 
   private var originalUri: Uri? = null
@@ -56,7 +61,9 @@ class MuxDataSource private constructor(
         .build()
     }
 
-    this.originalUri = uri
+    this.originalUri = dataSpec.uri
+    Log.d(TAG, "Modified URL\n\tFrom: ${dataSpec.uri}\n\tTo: $proxyUri")
+
     return upstreamSrc.open(dataSpec.withUri(proxyUri))
   }
 


### PR DESCRIPTION
Still a draft because I need to charge a device to test it

Quick Summary of Changes:
* All I/O for responses and files is now buffered.
* CDN Response bodies are no longer parsed to string.
* Writes from CDN to the Player and Disk are now interleaved synchronously. I am very sure this will be fast enough, and it saves a Thread
* `WriteHandle` and `ReadHandle` do all the I/O that involves the cache. Proxy classes just send the stream, and the Cache decides what it saves (this will be even better when I do eviction this week, and even better than that when we do content-ranges)
* No need to rewrite manifests. We change URLs before they get to the proxy, segments and playlists both go through DataSource