### PR TITLE
Skeleton for DRM Integration

### DIFF
--- a/library/src/main/java/com/mux/player/Util.kt
+++ b/library/src/main/java/com/mux/player/Util.kt
@@ -1,6 +1,5 @@
 package com.mux.player
 
-import android.net.Uri
 import kotlin.math.ceil
 
 /**

--- a/library/src/main/java/com/mux/player/Util.kt
+++ b/library/src/main/java/com/mux/player/Util.kt
@@ -1,5 +1,6 @@
 package com.mux.player
 
+import android.net.Uri
 import kotlin.math.ceil
 
 /**

--- a/library/src/main/java/com/mux/player/internal/Constants.kt
+++ b/library/src/main/java/com/mux/player/internal/Constants.kt
@@ -1,0 +1,6 @@
+package com.mux.player.internal
+
+internal object Constants {
+  const val BUNDLE_DRM_TOKEN = "drm key"
+  const val BUNDLE_PLAYBACK_ID = "drm key"
+}

--- a/library/src/main/java/com/mux/player/internal/InternalUtils.kt
+++ b/library/src/main/java/com/mux/player/internal/InternalUtils.kt
@@ -1,0 +1,35 @@
+package com.mux.player.internal
+
+import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSourceInputStream
+import androidx.media3.datasource.DataSpec
+import kotlin.jvm.Throws
+
+@Throws
+@JvmSynthetic
+@OptIn(UnstableApi::class)
+internal fun executePost(
+  uri: Uri,
+  headers: Map<String, List<String>>,
+  requestBody: ByteArray,
+  dataSourceFactory: DataSource.Factory,
+  ): ByteArray {
+  val dataSpec = DataSpec.Builder()
+    .setUri(uri)
+    .setHttpRequestHeaders(headers.mapValues { it.value.last() })
+    .setHttpBody(requestBody)
+    .build()
+
+  val dataSource = dataSourceFactory.createDataSource()
+  try {
+    dataSource.open(dataSpec)
+    DataSourceInputStream(dataSource, dataSpec).use { bodyInputStream ->
+      return bodyInputStream.readBytes()
+    }
+  } finally {
+    runCatching { dataSource.close() }
+  }
+}

--- a/library/src/main/java/com/mux/player/media/MediaItems.kt
+++ b/library/src/main/java/com/mux/player/media/MediaItems.kt
@@ -1,8 +1,10 @@
 package com.mux.player.media
 
 import android.net.Uri
+import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaItem.RequestMetadata
+import com.mux.player.internal.Constants
 
 /**
  * Creates instances of [MediaItem] or [MediaItem.Builder] configured for easy use with
@@ -38,6 +40,7 @@ object MediaItems {
     renditionOrder: RenditionOrder? = null,
     domain: String = MUX_VIDEO_DEFAULT_DOMAIN,
     playbackToken: String? = null,
+    drmToken: String? = null,
   ): MediaItem = builderFromMuxPlaybackId(
     playbackId,
     maxResolution,
@@ -45,7 +48,9 @@ object MediaItems {
     renditionOrder,
     domain,
     playbackToken,
+    drmToken
   ).build()
+
 
   /**
    * Creates a new [MediaItem.Builder] that points to a given Mux Playback ID. You can add
@@ -65,6 +70,7 @@ object MediaItems {
     renditionOrder: RenditionOrder? = null,
     domain: String = MUX_VIDEO_DEFAULT_DOMAIN,
     playbackToken: String? = null,
+    drmToken: String? = null,
   ): MediaItem.Builder {
     return MediaItem.Builder()
       .setUri(
@@ -79,6 +85,12 @@ object MediaItems {
       )
       .setRequestMetadata(
         RequestMetadata.Builder()
+          .setExtras(
+            Bundle().apply {
+              putString(Constants.BUNDLE_DRM_TOKEN, drmToken)
+              putString(Constants.BUNDLE_PLAYBACK_ID, playbackId)
+            }
+          )
           .build()
       )
   }

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -1,0 +1,60 @@
+package com.mux.player.media
+
+import androidx.annotation.GuardedBy
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaItem.DrmConfiguration
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
+import androidx.media3.exoplayer.drm.DrmSessionManager
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.drm.ExoMediaDrm
+import androidx.media3.exoplayer.drm.FrameworkMediaDrm
+import androidx.media3.exoplayer.drm.MediaDrmCallback
+import java.util.UUID
+
+@OptIn(UnstableApi::class)
+class MuxDrmSessionManagerProvider(
+  val drmHttpDataSourceFactory: HttpDataSource.Factory,
+) : DrmSessionManagerProvider {
+
+  private val sessionManager by lazy(LazyThreadSafetyMode.SYNCHRONIZED) { createSessionManager() }
+
+  override fun get(mediaItem: MediaItem): DrmSessionManager {
+    return sessionManager
+  }
+
+  private fun createSessionManager(): DrmSessionManager {
+    // todo - configure DRMSessionManager correctly
+
+    // QUESTIONS FOR CHRISTIAN
+    //  playClearSamplesWithoutKeys?
+    //  force drm sessions for any track types?
+
+    return DefaultDrmSessionManager.Builder()
+      .setUuidAndExoMediaDrmProvider(C.WIDEVINE_UUID, FrameworkMediaDrm.DEFAULT_PROVIDER)
+      .setMultiSession(false)
+      .setPlayClearSamplesWithoutKeys(true) // todo - right??
+      .build(MuxDrmCallback(drmHttpDataSourceFactory))
+  }
+}
+
+@OptIn(UnstableApi::class)
+class MuxDrmCallback(
+  val drmHttpDataSourceFactory: HttpDataSource.Factory
+) : MediaDrmCallback {
+
+  override fun executeProvisionRequest(
+    uuid: UUID,
+    request: ExoMediaDrm.ProvisionRequest
+  ): ByteArray {
+    TODO("Not yet implemented")
+  }
+
+  override fun executeKeyRequest(uuid: UUID, request: ExoMediaDrm.KeyRequest): ByteArray {
+    TODO("Not yet implemented")
+  }
+
+}

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -88,6 +88,8 @@ class MuxDrmCallback(
     request: ExoMediaDrm.ProvisionRequest
   ): ByteArray {
     TODO("Not yet implemented")
+
+
   }
 
   override fun executeKeyRequest(uuid: UUID, request: ExoMediaDrm.KeyRequest): ByteArray {

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -27,6 +27,8 @@ class MuxDrmSessionManagerProvider(
   override fun get(mediaItem: MediaItem): DrmSessionManager {
     synchronized(lock) {
       val currentSessionManager = sessionManager
+      // todo - do we need to change for every new media item? or just if drm key is different?
+      //  i think we *do* want to do make new session managers for new keys && new playbackIds
       if (currentSessionManager != null && this.mediaItem == mediaItem) {
         return currentSessionManager
       } else {

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -2,9 +2,13 @@ package com.mux.player.media
 
 import android.content.Context
 import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.drm.DrmSessionManager
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.CmcdConfiguration
@@ -32,7 +36,15 @@ class MuxMediaSourceFactory @JvmOverloads constructor(
 ) : MediaSource.Factory by innerFactory {
 
   init {
+    // basics
     innerFactory.setCmcdConfigurationFactory(CmcdConfiguration.Factory.DEFAULT)
     innerFactory.setDataSourceFactory(dataSourceFactory)
+
+    // drm
+    innerFactory.setDrmSessionManagerProvider(MuxDrmSessionManagerProvider(
+      drmHttpDataSourceFactory = DefaultHttpDataSource.Factory()
+    ))
   }
 }
+
+


### PR DESCRIPTION
We implement our own `DrmSessionManagerProvider` so we can send license requests as required