### PR TITLE
update: use bandwidth metering when cache is enabled

### DIFF
--- a/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/SimplePlayerTestActivity.java
+++ b/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/SimplePlayerTestActivity.java
@@ -20,6 +20,7 @@ import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.Player;
+import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.RenderersFactory;
@@ -144,7 +145,7 @@ public class SimplePlayerTestActivity extends AppCompatActivity implements Analy
     DefaultTrackSelector.Parameters trackSelectorParameters = builder
         .build();
 
-    mediaSourceFactory = new MuxMediaSourceFactory(this);
+    mediaSourceFactory = new MuxMediaSourceFactory(this, new DefaultDataSource.Factory(this));
     trackSelector = new DefaultTrackSelector(/* context= */ this, trackSelectionFactory);
     trackSelector.setParameters(trackSelectorParameters);
     RenderersFactory renderersFactory = new DefaultRenderersFactory(/* context= */ this);

--- a/library/src/androidTest/java/com/mux/player/CacheDatastoreInstrumentationTests.kt
+++ b/library/src/androidTest/java/com/mux/player/CacheDatastoreInstrumentationTests.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.mux.player.internal.cache.CacheConstants
+import com.mux.player.internal.Constants
 import com.mux.player.internal.cache.CacheDatastore
 import com.mux.player.internal.cache.FileRecord
 import com.mux.player.internal.cache.filesDirNoBackupCompat
@@ -356,11 +356,11 @@ class CacheDatastoreInstrumentationTests {
   }
 
   private fun expectedFileTempDir(context: Context): File =
-    File(context.cacheDir, CacheConstants.TEMP_FILE_DIR)
+    File(context.cacheDir, Constants.TEMP_FILE_DIR)
 
   private fun expectedFileCacheDir(context: Context): File =
-    File(context.cacheDir, CacheConstants.CACHE_FILES_DIR)
+    File(context.cacheDir, Constants.CACHE_FILES_DIR)
 
   private fun expectedIndexDbDir(context: Context): File =
-    File(context.filesDirNoBackupCompat, CacheConstants.CACHE_BASE_DIR)
+    File(context.filesDirNoBackupCompat, Constants.CACHE_BASE_DIR)
 }

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -249,8 +249,9 @@ class MuxPlayer private constructor(
     }
 
     private fun setUpMediaSourceFactory(builder: ExoPlayer.Builder) {
+      // todo - probably always use MuxMediaSource
       val mediaSourceFactory = if (enableSmartCache) {
-        MuxMediaSourceFactory(context, MuxDataSource.Factory())
+        MuxMediaSourceFactory(context, DefaultDataSource.Factory(context, MuxDataSource.Factory()))
       } else {
         MuxMediaSourceFactory(context, DefaultDataSource.Factory(context))
       }

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -1,10 +1,14 @@
 package com.mux.player
 
 import android.content.Context
+import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player.Listener
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.mux.player.internal.cache.CacheController
 import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
@@ -96,7 +100,7 @@ class MuxPlayer private constructor(
         device = muxPlayerDevice,
         network = network,
         playerBinding = exoPlayerBinding,
-        )
+      )
     }
   }
 
@@ -249,10 +253,19 @@ class MuxPlayer private constructor(
       return this
     }
 
+    @OptIn(UnstableApi::class)
     private fun setUpMediaSourceFactory(builder: ExoPlayer.Builder) {
-      // todo - probably always use MuxMediaSource
       val mediaSourceFactory = if (enableSmartCache) {
-        MuxMediaSourceFactory(context, DefaultDataSource.Factory(context, MuxDataSource.Factory()))
+        MuxMediaSourceFactory(
+          context,
+          // Set up a DefaultDataSourceFactory delegates to Mux for http/https
+          dataSourceFactory = DefaultDataSource.Factory(
+            context,
+            /* baseDataSourceFactory = */ MuxDataSource.Factory(
+              bandwidthMeterProvider = { DefaultBandwidthMeter.getSingletonInstance(context) }
+            )
+          )
+        )
       } else {
         MuxMediaSourceFactory(context, DefaultDataSource.Factory(context))
       }

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -1,10 +1,14 @@
 package com.mux.player
 
 import android.content.Context
+import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player.Listener
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.mux.player.internal.cache.CacheController
 import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
@@ -96,7 +100,7 @@ class MuxPlayer private constructor(
         device = muxPlayerDevice,
         network = network,
         playerBinding = exoPlayerBinding,
-        )
+      )
     }
   }
 
@@ -248,10 +252,19 @@ class MuxPlayer private constructor(
       return this
     }
 
+    @OptIn(UnstableApi::class)
     private fun setUpMediaSourceFactory(builder: ExoPlayer.Builder) {
-      // todo - probably always use MuxMediaSource
       val mediaSourceFactory = if (enableSmartCache) {
-        MuxMediaSourceFactory(context, DefaultDataSource.Factory(context, MuxDataSource.Factory()))
+        MuxMediaSourceFactory(
+          context,
+          // Set up a DefaultDataSourceFactory delegates to Mux for http/https
+          dataSourceFactory = DefaultDataSource.Factory(
+            context,
+            /* baseDataSourceFactory = */ MuxDataSource.Factory(
+              bandwidthMeterProvider = { DefaultBandwidthMeter.getSingletonInstance(context) }
+            )
+          )
+        )
       } else {
         MuxMediaSourceFactory(context, DefaultDataSource.Factory(context))
       }

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -230,6 +230,7 @@ class MuxPlayer private constructor(
         context = context,
         exoPlayer = this.playerBuilder.build(),
         muxDataKey = this.dataEnvKey,
+        muxCacheEnabled = enableSmartCache,
         logger = logger ?: createNoLogger(),
         initialCustomerData = customerData,
         network = network,
@@ -249,8 +250,9 @@ class MuxPlayer private constructor(
     }
 
     private fun setUpMediaSourceFactory(builder: ExoPlayer.Builder) {
+      // todo - probably always use MuxMediaSource
       val mediaSourceFactory = if (enableSmartCache) {
-        MuxMediaSourceFactory(context, MuxDataSource.Factory())
+        MuxMediaSourceFactory(context, DefaultDataSource.Factory(context, MuxDataSource.Factory()))
       } else {
         MuxMediaSourceFactory(context, DefaultDataSource.Factory(context))
       }

--- a/library/src/main/java/com/mux/player/internal/Constants.kt
+++ b/library/src/main/java/com/mux/player/internal/Constants.kt
@@ -1,13 +1,11 @@
-package com.mux.player.internal.cache
+package com.mux.player.internal
 
-internal object CacheConstants {
+internal object Constants {
   const val MIME_TS = "video/MP2T"
   const val MIME_M4S = "video/mp4"
   const val MIME_M4S_ALT = "video/iso.segment"
   const val EXT_M4S = "m4s"
   const val EXT_TS = "ts"
-
-  const val PROXY_PORT = 6000
 
   /**
    * Can be rooted in cache or files dir on either internal or external storage

--- a/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
@@ -5,7 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.os.Build
 import android.util.Base64
-import android.util.Log
+import com.mux.player.internal.Constants
 import com.mux.player.oneOf
 import java.io.Closeable
 import java.io.File
@@ -121,8 +121,6 @@ internal class CacheDatastore(
       )
     }
 
-    Log.v(TAG, "Wrote to row $rowId")
-
     return if (rowId >= 0) {
       Result.success(Unit)
     } else {
@@ -169,19 +167,19 @@ internal class CacheDatastore(
    * downloaded. Temp files are deleted on JVM exit. Every temp file is unique, preventing
    * collisions between multiple potential writers to the same file
    */
-  fun fileTempDir(): File = File(context.cacheDir, CacheConstants.TEMP_FILE_DIR)
+  fun fileTempDir(): File = File(context.cacheDir, Constants.TEMP_FILE_DIR)
 
   /**
    * A subdirectory within the app's cache dir where we keep cached media files that have been
    * committed to the cache with `WriteHandle.finishedWriting`. Temp files are guaranteed not to be
    * open for writing or appending, and their content can be relied upon assuming the file exists
    */
-  fun fileCacheDir(): File = File(context.cacheDir, CacheConstants.CACHE_FILES_DIR)
+  fun fileCacheDir(): File = File(context.cacheDir, Constants.CACHE_FILES_DIR)
 
   /**
    * A subdirectory within an app's no-backup files dir that contains the cache's index
    */
-  fun indexDbDir(): File = File(context.filesDirNoBackupCompat, CacheConstants.CACHE_BASE_DIR)
+  fun indexDbDir(): File = File(context.filesDirNoBackupCompat, Constants.CACHE_BASE_DIR)
 
   /**
    * Generates a URL-safe cache key for a given URL. Delegates to [generateCacheKey] but encodes it
@@ -232,7 +230,7 @@ internal class CacheDatastore(
       urlStr
     } else {
       val extension = matchResult.groups[3]!!.value
-      val isSegment = extension.oneOf(CacheConstants.EXT_TS, CacheConstants.EXT_M4S)
+      val isSegment = extension.oneOf(Constants.EXT_TS, Constants.EXT_M4S)
 
       if (isSegment) {
         // todo - we can pull out more-specific key parts using groups 2 and 1 if we want, but the
@@ -270,13 +268,11 @@ internal class CacheDatastore(
 
       // todo - remember to skip files that CacheController knows are already being read
       val candidates = doReadLeastRecentFiles(db)
-      Log.i(TAG, "About to evict ${candidates.map { it.relativePath }}")
       candidates.forEach { candidate ->
         File(fileCacheDir(), candidate.relativePath).delete()
       }
       // remove last so we don't leave orphans
       val deleteResult = doDeleteRecords(db, candidates)
-      Log.v(TAG, "deleted $deleteResult records")
 
       if (deleteResult.isSuccess) {
         db.setTransactionSuccessful()
@@ -432,12 +428,8 @@ internal class CacheDatastore(
       }
       return actualTask.get()
     } catch (e: Exception) {
-      // todo - get a Logger down here
-      Log.e("CacheDatastore", "failed to open cache", e)
-
       // subsequent calls can attempt again
       openTask.set(null)
-
       throw IOException(e)
     }
   }

--- a/library/src/main/java/com/mux/player/internal/cache/CacheUtils.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheUtils.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.database.Cursor
 import android.os.Build
+import com.mux.player.internal.Constants
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -49,9 +50,9 @@ internal fun InputStream.consumeInto(outputStream: OutputStream, readSize: Int =
 
 @JvmSynthetic
 internal fun isContentTypeSegment(contentTypeHeader: String?): Boolean {
-  return contentTypeHeader.equals(CacheConstants.MIME_TS, true)
-          || contentTypeHeader.equals(CacheConstants.MIME_M4S, true)
-          || contentTypeHeader.equals(CacheConstants.MIME_M4S_ALT, true)
+  return contentTypeHeader.equals(Constants.MIME_TS, true)
+          || contentTypeHeader.equals(Constants.MIME_M4S, true)
+          || contentTypeHeader.equals(Constants.MIME_M4S_ALT, true)
 }
 
 @JvmSynthetic

--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -13,6 +13,8 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.HttpDataSource.HttpDataSourceException
 import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
+import androidx.media3.exoplayer.upstream.BandwidthMeter
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.google.common.net.HttpHeaders
 import com.mux.player.internal.cache.CacheController
 import com.mux.player.internal.cache.ReadHandle
@@ -25,7 +27,8 @@ import java.net.URL
 
 @OptIn(UnstableApi::class)
 class MuxDataSource private constructor(
-  val upstreamSrcFac: HttpDataSource.Factory,
+  private val upstreamSrcFac: HttpDataSource.Factory,
+  private val bandwidthMeterProvider: () -> BandwidthMeter // add to DataSources created in here
 ) : BaseDataSource(false) {
 
   /**
@@ -33,10 +36,11 @@ class MuxDataSource private constructor(
    * data that Mux's cache cannot provide
    */
   class Factory(
-    private val upstream: HttpDataSource.Factory = DefaultHttpDataSource.Factory()
+    private val upstream: HttpDataSource.Factory = DefaultHttpDataSource.Factory(),
+    private val bandwidthMeterProvider: () -> BandwidthMeter
   ) : DataSource.Factory {
     override fun createDataSource(): DataSource {
-      return MuxDataSource(upstream)
+      return MuxDataSource(upstream, bandwidthMeterProvider)
     }
   }
 
@@ -131,8 +135,9 @@ class MuxDataSource private constructor(
   private fun openAndInitFromRemote(dataSpec: DataSpec, fac: HttpDataSource.Factory): Long {
     respondingFromCache = false
     val upstream = fac.createDataSource()
-
+    bandwidthMeterProvider().transferListener?.let { upstream.addTransferListener(it) }
     this.upstream = upstream
+
     val available = upstream.open(dataSpec)
     cacheWriter = CacheController.startWriting(
       dataSpec.uri.toString(),
@@ -182,6 +187,8 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
   override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
     val readBytes = bodyInputSteam?.read(buffer, offset, length) ?: 0
 
+    bytesTransferred(readBytes)
+
     return if (readBytes == -1) {
       C.RESULT_END_OF_INPUT
     } else {
@@ -191,6 +198,8 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
   }
 
   override fun open(dataSpec: DataSpec): Long {
+    transferInitializing(dataSpec)
+
     val conn = try {
       val hurlConn = createConnection(dataSpec, requestHeaders)
       this.responseCode = hurlConn.responseCode
@@ -207,10 +216,12 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
     val code = conn.responseCode
     val msg = conn.responseMessage
     if (code == HttpURLConnection.HTTP_NOT_MODIFIED) {
+      transferEnded()
       // not-modified, not an error, we don't have to download the body again
       runCatching { conn.disconnect() }
       return 0
     } else if (code < 200 || code > 299) {
+      transferEnded()
       // some kind of error
       val errorBody = conn.errorStream.use { errorBody -> errorBody.readBytes() }
       throw InvalidResponseCodeException(
@@ -228,6 +239,7 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
         transferStarted(dataSpec)
         stream
       } catch (e: IOException) {
+        transferEnded()
         closeConnection()
         throw HttpDataSourceException(
           e,
@@ -237,6 +249,7 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
         )
       }
 
+      transferStarted(dataSpec)
       this.bodyInputSteam = bodyStream
       this.open = true
       //return 0 // todo = bodyInputStream.available()? returning 0 all the time is technically ok tho

--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -141,6 +141,7 @@ class MuxDataSource private constructor(
   private fun openAndInitFromRemote(dataSpec: DataSpec, fac: HttpDataSource.Factory): Long {
     respondingFromCache = false
     val upstream = fac.createDataSource()
+
     this.upstream = upstream
     val available = upstream.open(dataSpec)
     cacheWriter = CacheController.downloadStarted(

--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -13,6 +13,8 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.HttpDataSource.HttpDataSourceException
 import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
+import androidx.media3.exoplayer.upstream.BandwidthMeter
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.google.common.net.HttpHeaders
 import com.mux.player.internal.cache.CacheController
 import com.mux.player.internal.cache.ReadHandle
@@ -25,7 +27,8 @@ import java.net.URL
 
 @OptIn(UnstableApi::class)
 class MuxDataSource private constructor(
-  val upstreamSrcFac: HttpDataSource.Factory,
+  private val upstreamSrcFac: HttpDataSource.Factory,
+  private val bandwidthMeterProvider: () -> BandwidthMeter // add to DataSources created in here
 ) : BaseDataSource(false) {
 
   /**
@@ -33,10 +36,11 @@ class MuxDataSource private constructor(
    * data that Mux's cache cannot provide
    */
   class Factory(
-    private val upstream: HttpDataSource.Factory = DefaultHttpDataSource.Factory()
+    private val upstream: HttpDataSource.Factory = DefaultHttpDataSource.Factory(),
+    private val bandwidthMeterProvider: () -> BandwidthMeter
   ) : DataSource.Factory {
     override fun createDataSource(): DataSource {
-      return MuxDataSource(upstream)
+      return MuxDataSource(upstream, bandwidthMeterProvider)
     }
   }
 
@@ -132,8 +136,6 @@ class MuxDataSource private constructor(
       upstream.close()
       this.upstream = null
 
-      // todo -
-
       openAndInitFromCache(readHandle)
     }
   }
@@ -141,8 +143,9 @@ class MuxDataSource private constructor(
   private fun openAndInitFromRemote(dataSpec: DataSpec, fac: HttpDataSource.Factory): Long {
     respondingFromCache = false
     val upstream = fac.createDataSource()
-
+    bandwidthMeterProvider().transferListener?.let { upstream.addTransferListener(it) }
     this.upstream = upstream
+
     val available = upstream.open(dataSpec)
     cacheWriter = CacheController.downloadStarted(
       dataSpec.uri.toString(),
@@ -192,6 +195,8 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
   override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
     val readBytes = bodyInputSteam?.read(buffer, offset, length) ?: 0
 
+    bytesTransferred(readBytes)
+
     return if (readBytes == -1) {
       C.RESULT_END_OF_INPUT
     } else {
@@ -201,6 +206,8 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
   }
 
   override fun open(dataSpec: DataSpec): Long {
+    transferInitializing(dataSpec)
+
     val conn = try {
       val hurlConn = createConnection(dataSpec, requestHeaders)
       this.responseCode = hurlConn.responseCode
@@ -217,9 +224,11 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
     val code = conn.responseCode
     val msg = conn.responseMessage
     if (code == HttpURLConnection.HTTP_NOT_MODIFIED) {
+      transferEnded()
       // not-modified, not an error, we don't have to download the body again
       return 0
     } else if (code < 200 || code > 299) {
+      transferEnded()
       // some kind of error
       val errorBody = conn.errorStream.use { errorBody -> errorBody.readBytes() }
       throw InvalidResponseCodeException(
@@ -237,6 +246,7 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
         transferStarted(dataSpec)
         stream
       } catch (e: IOException) {
+        transferEnded()
         closeConnection()
         throw HttpDataSourceException(
           e,
@@ -246,6 +256,7 @@ private class RevalidatingDataSource : BaseDataSource(true), HttpDataSource {
         )
       }
 
+      transferStarted(dataSpec)
       this.bodyInputSteam = bodyStream
       this.open = true
       //return 0 // todo = bodyInputStream.available()? returning 0 all the time is technically ok tho

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
-import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.CmcdConfiguration

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -27,7 +27,7 @@ import androidx.media3.exoplayer.upstream.CmcdConfiguration
 @OptIn(UnstableApi::class)
 class MuxMediaSourceFactory @JvmOverloads constructor(
   ctx: Context,
-  dataSourceFactory: DataSource.Factory = DefaultDataSource.Factory(ctx),
+  dataSourceFactory: DataSource.Factory,
   private val innerFactory: DefaultMediaSourceFactory = DefaultMediaSourceFactory(ctx),
 ) : MediaSource.Factory by innerFactory {
 


### PR DESCRIPTION
We don't need to change the `DefaultBandwidthMeter` because the `DataSource` is entirely responsible for reporting its own bandwidth stats. The approach we take instead is to report data transfer only when the `DataSource` is transferring from a remote data source.

* `MuxDataSource` never reports its own data transfer stats. Instead it attaches the `BandwidthMeter` to the `DataSource`s delegated-to, which are responsible for reporting their stats normally.
* `RevalidatingDataSource` reports its own stats directly only if we have a response body to download (eg, an expired entry)