### PR TITLE
fix: crash due to closed DbHelper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ automatedtests/automated_test_results/**
 
 # Test data
 *.raw
+.kotlin

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -57,13 +57,6 @@ class MuxPlayer private constructor(
     // exoPlayer can handle multiple calls itself, not our deal
     exoPlayer.release()
 
-    // our own cleanup should only happen once
-    if (!released) {
-      if (muxCacheEnabled) {
-        CacheController.onPlayerReleased()
-      }
-    }
-
     released = true
   }
 

--- a/library/src/main/java/com/mux/player/internal/cache/CacheController.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheController.kt
@@ -119,39 +119,7 @@ internal object CacheController {
    */
   @JvmSynthetic
   internal fun onPlayerCreated() {
-    val totalPlayersBefore = playersWithCache.getAndIncrement()
-    if (totalPlayersBefore == 0) {
-      ioScope.launch { datastore.open() }
-    }
-  }
-
-  /**
-   * Call internally when a MuxPlayer is released if caching was enabled.
-   *
-   * Try to call only once per player, even if caller calls release() multiple times
-   */
-  @JvmSynthetic
-  internal fun onPlayerReleased() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      closeDatastoreApiN()
-    } else {
-      closeDatastoreLegacy()
-    }
-  }
-
-  @TargetApi(Build.VERSION_CODES.N)
-  private fun closeDatastoreApiN() {
-    val totalPlayersNow = playersWithCache.updateAndGet { if (it > 0) it - 1 else it }
-    if (totalPlayersNow == 0) {
-      ioScope.launch { datastore.close() }
-    }
-  }
-
-  private fun closeDatastoreLegacy() {
-    val totalPlayersNow = playersWithCache.decrementAndGet()
-    if (totalPlayersNow == 0) {
-      ioScope.launch { datastore.close() }
-    }
+    ioScope.launch { datastore.open() }
   }
 
   /**

--- a/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
@@ -37,7 +37,6 @@ internal class CacheDatastore(
       Regex("""^https://[^/]*/v1/chunk/([^/]*)/([^/]*)\.(m4s|ts)""")
   }
 
-
   private val dbHelper: DbHelper get() = awaitDbHelper()
 
   /**


### PR DESCRIPTION
Removing `SQLiteOpenHelper.close()` sounds odd at first, but this is a safe change on API 21+ (which is all Mux Player supports). On modern android, all you need to `close()` is `Cursor` and `SQLiteDatabase` itself. The system will cache the database connections for us. 

At one point, I thought there were supporting platforms version where this wasn't true, but I did some research and we should be good with this. 

### But why

Starting a few versions before Marshmallow/API21, the `SQLite*` classes were refactored, such that database connections are ref-counted & cached by the Android internals. The `SQLiteDatabse` object returned by `SQLiteOpenHelper::getWriteableDatabase()` is the same object every time, and the `SQLiteDatabase` itself has counting and caching logic around the DB connection (the thing you need to worry about dangling).  

The safest thing to do on the API levels we support is to leverage the system. We call`getWriteableDatabase()` every time we need a db object, and `close()` it safely using `finally`/`use() {...}`/try-with-resources. This allows `SQLiteDatabase` to manage DB connections for us using its own ref-counting.

edit:
Also, calling `SQLiteOpenHelper.close()` won't close any `SQLiteDatabase`s that are still in-use or dangling, so doing it doesn't even help. They'd stay cached forever even if you called `close()` on the OpenHelper.