### PR TITLE
fix: Cache errors when rapidly switching sources

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,6 +16,8 @@ android {
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
+
+    multiDexEnabled true
   }
 
   buildTypes {

--- a/library/src/androidTest/java/com/mux/player/CacheDatastoreInstrumentationTests.kt
+++ b/library/src/androidTest/java/com/mux/player/CacheDatastoreInstrumentationTests.kt
@@ -8,6 +8,7 @@ import com.mux.player.internal.Constants
 import com.mux.player.internal.cache.CacheDatastore
 import com.mux.player.internal.cache.FileRecord
 import com.mux.player.internal.cache.filesDirNoBackupCompat
+import com.mux.player.internal.createLogcatLogger
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -56,7 +57,7 @@ class CacheDatastoreInstrumentationTests {
 
   @Test
   fun testBasicInitialization() {
-    val datastore = CacheDatastore(appContext)
+    val datastore = CacheDatastore(appContext, logger = createLogcatLogger())
     datastore.use { it.open() }
 
     Assert.assertTrue(
@@ -80,7 +81,7 @@ class CacheDatastoreInstrumentationTests {
 
   @Test
   fun testCreateTempDownloadFile() {
-    val datastore = CacheDatastore(appContext)
+    val datastore = CacheDatastore(appContext, logger = createLogcatLogger())
     datastore.use {
       it.open()
 
@@ -102,7 +103,7 @@ class CacheDatastoreInstrumentationTests {
     val oldFileData = "old data".toByteArray(Charsets.UTF_8)
     val newFileData = "new data".toByteArray(Charsets.UTF_8)
 
-    val datastore = CacheDatastore(appContext)
+    val datastore = CacheDatastore(appContext, logger = createLogcatLogger())
     datastore.open()
     datastore.use {
       // Write one file...
@@ -132,7 +133,7 @@ class CacheDatastoreInstrumentationTests {
 
   @Test
   fun testWriteRecordReplacesOnKey() {
-    val datastore = CacheDatastore(appContext)
+    val datastore = CacheDatastore(appContext, logger = createLogcatLogger())
     datastore.use {
       datastore.open()
 
@@ -183,7 +184,7 @@ class CacheDatastoreInstrumentationTests {
   @Test
   fun testReadRecord() {
     fun testTheCase(url: String) {
-      CacheDatastore(appContext).use { datastore ->
+      CacheDatastore(appContext, logger = createLogcatLogger()).use { datastore ->
         datastore.open()
         
         val originalRecord = FileRecord(
@@ -216,7 +217,7 @@ class CacheDatastoreInstrumentationTests {
   @Test
   fun testReadLeastRecentFiles() {
     val maxCacheSize = 5L
-    CacheDatastore(appContext, maxDiskSize = maxCacheSize).use { datastore ->
+    CacheDatastore(appContext, maxDiskSize = maxCacheSize, createLogcatLogger()).use { datastore ->
       datastore.open()
       // For this test, size "units" are like one digit.
       //  time "units" start in the 3-digit range and tick at ~10 units per call to fakeNow()
@@ -279,7 +280,7 @@ class CacheDatastoreInstrumentationTests {
     val maxCacheSize = 5500L
     val dummyFileSize = 1000L
 
-    CacheDatastore(appContext, maxDiskSize = maxCacheSize).use { datastore ->
+    CacheDatastore(appContext, maxDiskSize = maxCacheSize, createLogcatLogger()).use { datastore ->
       datastore.open()
       //  time "units" start in the 3-digit range and tick at ~10 units per call to fakeNow()
       var fakeLastAccess = 200L // increment by some amount when you need to

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -138,7 +138,10 @@ class MuxPlayer private constructor(
     private var customerData: CustomerData = CustomerData()
     private var exoPlayerBinding: ExoPlayerBinding? = null
     private var network: INetworkRequest? = null
-    private var muxPlayerCache: MuxPlayerCache = MuxPlayerCache.create(context.applicationContext)
+    private var muxPlayerCache: MuxPlayerCache = MuxPlayerCache.create(
+      context.applicationContext,
+      logger = logger ?: createNoLogger()
+    )
 
     constructor(context: Context) : this(context, ExoPlayer.Builder(context))
 

--- a/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
@@ -5,6 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.os.Build
 import android.util.Base64
+import android.util.Log
 import com.mux.player.internal.Constants
 import com.mux.player.oneOf
 import java.io.Closeable
@@ -127,6 +128,7 @@ internal class CacheDatastore(
   }
 
   fun readRecordByUrl(url: String): FileRecord? {
+    Log.i("CacheInvest", "readRecordByUrl() called for datastore $this\n\tfor url $url")
     return databaseOrThrow().use {
       it.query(
         IndexSql.Files.name, null,
@@ -134,6 +136,7 @@ internal class CacheDatastore(
         arrayOf(safeCacheKey(URL(url))),
         null, null, null
       ).use { cursor ->
+        Log.d("CacheInvest", "readRecordByUrl() about to talk to the cursor $cursor")
         if (cursor.count > 0 && cursor.moveToFirst()) {
           cursor.toFileRecord()
         } else {
@@ -182,6 +185,7 @@ internal class CacheDatastore(
 
   @Throws(IOException::class)
   override fun close() {
+    Log.i("CacheInvest", "close() called for datastore $this")
     synchronized(dbGuard) {
       // release reference from when we opened. if any loader threads are reading/writing then
       //  the db will close once they wind down

--- a/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
@@ -207,9 +207,6 @@ internal class CacheDatastore(
   override fun close() {
     logger.i("CacheInvest", "close() tid=${Thread.currentThread().id} called for datastore $this")
     synchronized(dbGuard) {
-      // release reference from when we opened. if any loader threads are reading/writing then
-      //  the db will close once they wind down
-//      dbHelper?.writableDatabase?.releaseReference()
       sqlDb?.close()
       dbHelper?.close()
       dbHelper = null
@@ -409,8 +406,6 @@ internal class CacheDatastore(
   @Throws(IOException::class)
   private fun databaseOrThrow(): SQLiteDatabase {
     synchronized(dbGuard) {
-//      val helper = dbHelper ?: throw IOException("CacheDatastore was closed")
-//      return helper.writableDatabase
       return sqlDb?.takeIf { it.isOpen } ?: throw IOException("CacheDatastore was closed")
     }
   }

--- a/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
@@ -8,6 +8,8 @@ import android.util.Base64
 import android.util.Log
 import com.google.common.cache.Cache
 import com.mux.player.internal.Constants
+import com.mux.player.internal.Logger
+import com.mux.player.internal.createNoLogger
 import com.mux.player.oneOf
 import java.io.Closeable
 import java.io.File
@@ -26,6 +28,7 @@ import java.net.URL
 internal class CacheDatastore(
   val context: Context,
   val maxDiskSize: Long = 256 * 1024 * 1024,
+  val logger: Logger,
 ) : Closeable {
 
   companion object {

--- a/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
@@ -131,7 +131,7 @@ internal class CacheDatastore(
   }
 
   fun readRecordByUrl(url: String): FileRecord? {
-    Log.i("CacheInvest", "readRecordByUrl() tid=${Thread.currentThread().id} called for datastore $this\n\tfor url $url")
+    logger.i("CacheInvest", "readRecordByUrl() tid=${Thread.currentThread().id} called for datastore $this\n\tfor url $url")
     try {
       return databaseOrThrow().run {
         query(
@@ -140,17 +140,17 @@ internal class CacheDatastore(
           arrayOf(safeCacheKey(URL(url))),
           null, null, null
         ).use { cursor ->
-          Log.d(
+          logger.d(
             "CacheInvest",
             "readRecordByUrl() tid=${Thread.currentThread().id} about to talk to the cursor $this\n\t btw is it closed according to Cursor? ${cursor.isClosed}"
           )
-          Log.i(
+          logger.i(
             "CacheInvest",
             "readRecordByUrl() tid=${Thread.currentThread().id} \n\tcursor closed ${cursor.isClosed}\n\t db closed ${!isOpen}"
           )
           if (cursor.count > 0 && cursor.moveToFirst()) {
             cursor.toFileRecord().also {
-              Log.i(
+              logger.i(
                 "CacheInvest",
                 "readRecordByUrl() tid=${Thread.currentThread().id} returning with record\n\tfor $url"
               )
@@ -161,7 +161,7 @@ internal class CacheDatastore(
         }
       }
     } catch (e: Exception) {
-      Log.e("CacheInvest", "rethrowing DB error from tid ${Thread.currentThread().id} for datastore $this", e)
+      logger.e("CacheInvest", "rethrowing DB error from tid ${Thread.currentThread().id} for datastore $this", e)
       throw e
     }
   }
@@ -205,7 +205,7 @@ internal class CacheDatastore(
 
   @Throws(IOException::class)
   override fun close() {
-    Log.i("CacheInvest", "close() tid=${Thread.currentThread().id} called for datastore $this")
+    logger.i("CacheInvest", "close() tid=${Thread.currentThread().id} called for datastore $this")
     synchronized(dbGuard) {
       // release reference from when we opened. if any loader threads are reading/writing then
       //  the db will close once they wind down

--- a/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/CacheDatastore.kt
@@ -221,7 +221,7 @@ internal class CacheDatastore(
   internal fun readLeastRecentFiles(): List<FileRecord> {
     // This function is only visible for testing. doReadLeastRecentFiles() is called internally in
     //  a transaction with an already-open db
-    return databaseOrThrow().let { doReadLeastRecentFiles(it) }
+    return doReadLeastRecentFiles(databaseOrThrow())
   }
 
   /**

--- a/library/src/main/java/com/mux/player/internal/cache/MuxPlayerCache.kt
+++ b/library/src/main/java/com/mux/player/internal/cache/MuxPlayerCache.kt
@@ -1,6 +1,8 @@
 package com.mux.player.internal.cache
 
 import android.content.Context
+import com.mux.player.internal.Logger
+import com.mux.player.internal.createNoLogger
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.Closeable
@@ -21,9 +23,11 @@ import java.util.concurrent.TimeUnit
  */
 class MuxPlayerCache private constructor(
   private val datastore: CacheDatastore,
+  private val logger: Logger,
 ) {
 
-  constructor(appContext: Context) : this(CacheDatastore(appContext.applicationContext))
+  constructor(appContext: Context, logger: Logger)
+      : this(CacheDatastore(appContext.applicationContext, logger = logger), logger)
 
   companion object {
     private const val TAG = "CacheController"
@@ -34,9 +38,10 @@ class MuxPlayerCache private constructor(
     val RX_S_MAX_AGE = Regex("""s-max-age=([0-9].*)""")
 
     @JvmSynthetic
-    internal fun create(appContext: Context) = MuxPlayerCache(appContext)
+    internal fun create(appContext: Context, logger: Logger) = MuxPlayerCache(appContext, logger)
     @JvmSynthetic
-    internal fun create(datastore: CacheDatastore) = MuxPlayerCache(datastore)
+    internal fun create(datastore: CacheDatastore, logger: Logger) =
+      MuxPlayerCache(datastore, logger)
   }
 
   /**

--- a/library/src/test/java/com/mux/player/CacheDatastoreTests.kt
+++ b/library/src/test/java/com/mux/player/CacheDatastoreTests.kt
@@ -2,6 +2,7 @@ package com.mux.player
 
 import android.content.Context
 import com.mux.player.internal.cache.CacheDatastore
+import com.mux.player.internal.createNoLogger
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert
@@ -21,7 +22,7 @@ class CacheDatastoreTests : AbsRobolectricTest() {
       }
     }
 
-    cacheDatastore = CacheDatastore(mockContext)
+    cacheDatastore = CacheDatastore(mockContext, logger = createNoLogger())
   }
 
   @Test

--- a/library/src/test/java/com/mux/player/MuxPlayerCacheTests.kt
+++ b/library/src/test/java/com/mux/player/MuxPlayerCacheTests.kt
@@ -3,6 +3,7 @@ package com.mux.player
 import android.content.Context
 import com.mux.player.internal.cache.MuxPlayerCache
 import com.mux.player.internal.cache.CacheDatastore
+import com.mux.player.internal.createNoLogger
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert
@@ -24,7 +25,7 @@ class MuxPlayerCacheTests : AbsRobolectricTest() {
       }
     }
 
-    muxPlayerCache = MuxPlayerCache.create(mockDatastore)
+    muxPlayerCache = MuxPlayerCache.create(mockDatastore, logger = createNoLogger())
   }
 
   @Test


### PR DESCRIPTION
Root cause: calling `SQLiteDatabase.close()` (via `use`) is not thread-safe, even though it appears to be. This is a problem because media3's loader is multithreaded. The `SQLiteDatabase` and `SQLiteCursor` all have guards around their init and closing logic, but the underlying `SQLiteConnectionPool` isn't guarded adequately in this case. Since a single `CacheDatastore` can be used by multiple loader threads (as-designed in media3), we can't rely on `SQLiteDatabase.close()`.

Because of all of that, rapidly switching media sources many times (like when fling-scrolling a feed) would occasionally result in playback errors

Solution: Explicitly keep an open `SQLiteDatabase` object around for as long as a `Player` needs a `CacheDatastore`. This is fine to do, and was the general intent of my last attempt at fixing this. Before, I was using `acquireReference` to hopefully keep the `SQLiteDatabase`'s underlying connection open even if `close()` was called. This wasn't effective thanks to media3's multithreaded loading behavior. Now, we just keep the DB object (and therefore connection) open until we are closed (when our `MuxPlayer` is released)