### PR TITLE
chore(dependencies): Update Media3 to 1.5.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk = 34
+  compileSdk = 35
 
   defaultConfig {
     minSdk = 21
-    targetSdk = 34
+    targetSdk = 35
     versionCode = 1
     versionName = "1.0"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,6 @@ plugins {
 
 allprojects {
   ext {
-    set("muxDataVersion", "1.6.0")
+    set("muxDataVersion", "1.6.2")
   }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
   namespace 'com.mux.player'
-  compileSdk 34
+  compileSdk 35
 
   defaultConfig {
     minSdk 21
     //noinspection EditedTargetSdkVersion
-    targetSdk 34
+    targetSdk 35
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -77,8 +77,8 @@ muxDistribution {
 
 dependencies {
 
-  def media3Version = "1.4.1"
-  def media3DataSdk = "at_1_4"
+  def media3Version = "1.5.0"
+  def media3DataSdk = "at_1_5"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"


### PR DESCRIPTION
I have a strange issue with the current release of mux-player-android that's forcing me to exclude the Media3 group from my dependencies. I haven't fully traced the issue but it's something to do with the fact that I end up with two versions of some of Media3 and Activities aren't being fully destroyed where they were before. It's very strange.

I've done the following for now
```
implementation(libs.mux) {
    exclude(group = "androidx.media3") 
  }
```
... but would be nice not to have to. 

I believe the following PR is all you need to update to 1.5.0 but feel free to let me know otherwise.