### PR TITLE
Fix example apps on API 35+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,11 +11,12 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MuxVideoMedia3"
-        tools:targetApi="31">
+        >
         <activity
             android:name=".examples.carousel.PlayerCarouselActivity"
             android:screenOrientation="sensorPortrait"
             android:exported="false"
+              android:theme="@style/Theme.MuxVideoMedia3.NoActionBar"
             tools:ignore="LockedOrientationActivity" />
         <activity
           android:name=".examples.BasicPlayerActivity"

--- a/app/src/main/java/com/mux/player/media3/MainActivity.kt
+++ b/app/src/main/java/com/mux/player/media3/MainActivity.kt
@@ -6,7 +6,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.mux.player.media3.databinding.ActivityMainBinding
@@ -25,6 +29,19 @@ class MainActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     binding = ActivityMainBinding.inflate(layoutInflater)
     setContentView(binding.root)
+
+    ViewCompat.setOnApplyWindowInsetsListener(binding.mainExampleTb) { v, insets ->
+      val bars = insets.getInsets(
+        WindowInsetsCompat.Type.systemBars()
+            or WindowInsetsCompat.Type.displayCutout()
+      )
+      v.updatePadding(
+        top = bars.top,
+        bottom = bars.bottom,
+      )
+      WindowInsetsCompat.CONSUMED
+    }
+
     examplesView.layoutManager = LinearLayoutManager(this)
 
     binding.mainExampleTb.apply {

--- a/app/src/main/java/com/mux/player/media3/examples/BasicPlayerActivity.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/BasicPlayerActivity.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -32,6 +33,9 @@ class BasicPlayerActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    WindowCompat.setDecorFitsSystemWindows(window, true)
+
     binding = ActivityBasicPlayerBinding.inflate(layoutInflater)
     setContentView(binding.root)
   }

--- a/app/src/main/java/com/mux/player/media3/examples/ConfigurablePlayerActivity.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/ConfigurablePlayerActivity.kt
@@ -14,6 +14,9 @@ import android.widget.Toast
 import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
@@ -51,6 +54,18 @@ class ConfigurablePlayerActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     binding = ActivityConfigurablePlayerBinding.inflate(layoutInflater)
     setContentView(binding.root)
+
+    ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
+      val bars = insets.getInsets(
+        WindowInsetsCompat.Type.systemBars()
+            or WindowInsetsCompat.Type.displayCutout()
+      )
+      v.updatePadding(
+        top = bars.top,
+        bottom = bars.bottom,
+      )
+      WindowInsetsCompat.CONSUMED
+    }
 
     if (savedInstanceState != null) {
       playbackParamsHelper.restoreInstanceState(savedInstanceState)

--- a/app/src/main/res/layout/activity_basic_player.xml
+++ b/app/src/main/res/layout/activity_basic_player.xml
@@ -10,7 +10,8 @@
     <androidx.media3.ui.PlayerView
       android:id="@+id/player"
       android:layout_width="match_parent"
-      android:layout_height="320dp"
+      android:layout_height="0dp"
+      app:layout_constraintDimensionRatio="4:3"
       app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_configurable_player.xml
+++ b/app/src/main/res/layout/activity_configurable_player.xml
@@ -13,7 +13,8 @@
     <androidx.media3.ui.PlayerView
       android:id="@+id/player"
       android:layout_width="match_parent"
-      android:layout_height="320dp"
+      android:layout_height="0dp"
+      app:layout_constraintDimensionRatio="4:3"
       app:layout_constraintTop_toTopOf="parent" />
 
     <LinearLayout


### PR DESCRIPTION
They changed the way window insets work, and our example apps were overlapping the statusbar and camera safe-area on some devices

This change isn't going in a release branch because it didn't require any SDK changes

It also makes the example player views a little bigger, which looks nicer