### PR TITLE
update: Update media3 version to 1.6.0 and Mux data to version 1.7.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,3 @@ plugins {
   id("com.android.library") version "8.8.2" apply false
   id("com.mux.gradle.android.mux-android-distribution") version "1.3.0" apply false
 }
-
-allprojects {
-  ext {
-    set("muxDataVersion", "1.6.2")
-  }
-}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,8 +77,9 @@ muxDistribution {
 
 dependencies {
 
-  def media3Version = "1.5.0"
-  def media3DataSdk = "at_1_5"
+  def media3Version = "1.6.0"
+  def muxDataVariant = "at_1_6"
+  def muxDataVersion = "1.7.3"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"
@@ -86,7 +87,7 @@ dependencies {
   api "androidx.media3:media3-exoplayer-ima:${media3Version}"
   api "androidx.media3:media3-cast:${media3Version}"
 
-  api("com.mux.stats.sdk.muxstats:data-media3-$media3DataSdk:${project.ext.get("muxDataVersion")}")
+  api("com.mux.stats.sdk.muxstats:data-media3-$muxDataVariant:$muxDataVersion")
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 


### PR DESCRIPTION
Both updates offer a bunch of fixes and new capabilities. Mostly, we want the media3 updates, but we hadn't updated Mux Data in a while either