### PR TITLE
fix: DRM playback broken + logging problems

### DIFF
--- a/app/src/main/java/com/mux/player/media3/examples/ConfigurablePlayerActivity.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/ConfigurablePlayerActivity.kt
@@ -180,6 +180,7 @@ class ConfigurablePlayerActivity : AppCompatActivity() {
         setSeekBackIncrementMs(10_000)
         setSeekForwardIncrementMs(30_000)
       }
+      .enableLogcat(true)
       .build()
 
     out.addListener(object : Player.Listener {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.application") version "8.8.2" apply false
-  id("org.jetbrains.kotlin.android") version "2.1.10" apply false
+  id("org.jetbrains.kotlin.android") version "2.1.20" apply false
   id("com.android.library") version "8.8.2" apply false
   id("com.mux.gradle.android.mux-android-distribution") version "1.3.0" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.application") version "8.8.2" apply false
-  id("org.jetbrains.kotlin.android") version "2.1.20" apply false
+  id("org.jetbrains.kotlin.android") version "2.1.10" apply false
   id("com.android.library") version "8.8.2" apply false
   id("com.mux.gradle.android.mux-android-distribution") version "1.3.0" apply false
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 
   def media3Version = "1.6.0"
   def muxDataVariant = "at_1_6"
-  def muxDataVersion = "1.7.2"
+  def muxDataVersion = "1.7.3"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 
   def media3Version = "1.6.0"
   def muxDataVariant = "at_1_6"
-  def muxDataVersion = "1.7.3"
+  def muxDataVersion = "1.7.2"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 
   def media3Version = "1.6.0"
   def muxDataVariant = "at_1_6"
-  def muxDataVersion = "1.7.3"
+  def muxDataVersion = "dev-fix-abstract-method-error-36ceea6"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 
   def media3Version = "1.6.0"
   def muxDataVariant = "at_1_6"
-  def muxDataVersion = "dev-fix-abstract-method-error-36ceea6"
+  def muxDataVersion = "dev-fix-abstract-method-error-1ee5cdc"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,7 +79,6 @@ dependencies {
 
   def media3Version = "1.6.1"
   def muxDataVariant = "at_1_6"
-  def muxDataVersion = "dev-fix-abstract-method-error-1ee5cdc"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"
@@ -87,7 +86,7 @@ dependencies {
   api "androidx.media3:media3-exoplayer-ima:${media3Version}"
   api "androidx.media3:media3-cast:${media3Version}"
 
-  api("com.mux.stats.sdk.muxstats:data-media3-$muxDataVariant:$muxDataVersion")
+  api("com.mux.stats.sdk.muxstats:data-media3-$muxDataVariant:1.6.2")
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 
   def media3Version = "1.6.0"
   def muxDataVariant = "at_1_6"
-  def muxDataVersion = "dev-releases-v1.7.4-1a1f992"
+  def muxDataVersion = "1.7.3"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,7 +77,7 @@ muxDistribution {
 
 dependencies {
 
-  def media3Version = "1.6.0"
+  def media3Version = "1.6.1"
   def muxDataVariant = "at_1_6"
   def muxDataVersion = "dev-fix-abstract-method-error-1ee5cdc"
   api "androidx.media3:media3-common:${media3Version}"

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -228,6 +228,7 @@ class MuxPlayer private constructor(
       } else {
         createNoLogger()
       }
+      setUpMediaSourceFactory(this.playerBuilder)
       return this
     }
 

--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -228,6 +228,7 @@ class MuxPlayer private constructor(
       } else {
         createNoLogger()
       }
+      // give our MediaSourceFactory the new logger
       setUpMediaSourceFactory(this.playerBuilder)
       return this
     }

--- a/library/src/main/java/com/mux/player/internal/InternalUtils.kt
+++ b/library/src/main/java/com/mux/player/internal/InternalUtils.kt
@@ -1,7 +1,6 @@
 package com.mux.player.internal
 
 import android.net.Uri
-import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
@@ -9,9 +8,6 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSourceInputStream
 import androidx.media3.datasource.DataSpec
 import com.mux.player.media.MediaItems.MUX_VIDEO_DEFAULT_DOMAIN
-import com.mux.player.media.MuxDrmCallback.Companion.TAG
-import com.mux.player.media.MuxDrmSessionManagerProvider
-import com.mux.player.media.MuxDrmSessionManagerProvider.Companion
 import kotlin.jvm.Throws
 
 @Throws

--- a/library/src/main/java/com/mux/player/internal/InternalUtils.kt
+++ b/library/src/main/java/com/mux/player/internal/InternalUtils.kt
@@ -16,7 +16,7 @@ import kotlin.jvm.Throws
 internal fun executePost(
   uri: Uri,
   headers: Map<String, List<String>>,
-  requestBody: ByteArray,
+  requestBody: ByteArray?,
   dataSourceFactory: DataSource.Factory,
   ): ByteArray {
   val dataSpec = DataSpec.Builder()

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -130,10 +130,12 @@ class MuxDrmCallback(
         emptyMap()
       )
     } catch (e: InvalidResponseCodeException) {
-      logger.d(TAG, "Dumping data spec: ${e.dataSpec}")
+      logger.e(TAG, "Provisioning/License Request failed!", e)
+      logger.d(TAG, "Failed data spec: ${e.dataSpec}")
       throw e
     } catch (e: HttpDataSourceException) {
       logger.e(TAG, "Provisioning Request failed!", e)
+      logger.d(TAG, "Failed data spec: ${e.dataSpec}")
       throw e
     } catch (e: Exception) {
       logger.e(TAG, "Provisioning Request failed!", e)
@@ -145,7 +147,7 @@ class MuxDrmCallback(
     uuid: UUID,
     request: KeyRequest
   ): ByteArray {
-    val widevine = uuid == C.WIDEVINE_UUID;
+    val widevine = uuid == C.WIDEVINE_UUID
     if (!widevine) {
       throw IOException("Mux player does not support scheme: $uuid")
     }
@@ -165,9 +167,11 @@ class MuxDrmCallback(
       )
     } catch (e: InvalidResponseCodeException) {
       logger.e(TAG, "key request failed!", e)
+      logger.d(TAG, "Failed data spec: ${e.dataSpec}")
       throw e
     } catch (e: HttpDataSourceException) {
       logger.e(TAG, "Key Request failed!", e)
+      logger.d(TAG, "Failed data spec: ${e.dataSpec}")
       throw e
     } catch (e: Exception) {
       logger.e(TAG, "KEY Request failed!", e)

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -1,5 +1,6 @@
 package com.mux.player.media
 
+import android.annotation.SuppressLint
 import android.net.Uri
 import android.util.Base64
 import android.util.Log
@@ -7,12 +8,14 @@ import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.Util
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.HttpDataSource.HttpDataSourceException
 import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
 import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.drm.DrmUtil
 import androidx.media3.exoplayer.drm.ExoMediaDrm.ProvisionRequest
 import androidx.media3.exoplayer.drm.ExoMediaDrm.KeyRequest
 import androidx.media3.exoplayer.drm.FrameworkMediaDrm
@@ -120,24 +123,38 @@ class MuxDrmCallback(
       throw IOException("Mux player does not support scheme: $uuid")
     }
 
-    val uri = createLicenseUri(playbackId, drmToken, licenseEndpointHost)
+//    val uri = createLicenseUri(playbackId, drmToken, licenseEndpointHost)
+    val url = request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data)
+    @SuppressLint("UseKtx") // TODO: Probably just include KTX and use that
+    val uri = Uri.parse(request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data))
+//    val uri = Uri.parse(request.defaultUrl)// + "&signedRequest=" + Util.fromUtf8Bytes(request.data))
+//      .buildUpon()
+//      .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
+//      .build()
     logger.d(TAG, "executeProvisionRequest: license URI is $uri")
-    val headers = mapOf(
-      "Content-Type" to listOf("application/octet-stream")
-    )
+//    val headers = mapOf(
+//      "Content-Type" to listOf("application/octet-stream")
+//    )
 
-    logger.v(TAG, "widevine data: ${Base64.encodeToString(request.data, Base64.NO_WRAP)}")
+//    logger.v(TAG, "widevine data: ${Base64.encodeToString(request.data, Base64.NO_WRAP)}")
 
 //    val decoded = Base64.decode(request.data, Base64.NO_WRAP)
 
     try {
-      return executePost(
-        uri,
-        headers = headers,
-        requestBody = request.data,
-//        requestBody = decoded,
-        dataSourceFactory = drmHttpDataSourceFactory,
-      ).also {
+//      return executePost(
+//        uri,
+//        headers = mapOf(),
+//        requestBody = null,
+////        requestBody = decoded,
+//        dataSourceFactory = drmHttpDataSourceFactory,
+//      )
+      return DrmUtil.executePost(
+        drmHttpDataSourceFactory.createDataSource(),
+        url,
+        null,
+        emptyMap()
+      )
+        .also {
         logger.i(TAG, "License Response: ${Base64.encodeToString(it, Base64.NO_WRAP)}")
       }
     } catch (e: InvalidResponseCodeException) {

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -128,11 +128,14 @@ class MuxDrmCallback(
 
     logger.v(TAG, "widevine data: ${Base64.encodeToString(request.data, Base64.NO_WRAP)}")
 
+//    val decoded = Base64.decode(request.data, Base64.NO_WRAP)
+
     try {
       return executePost(
         uri,
         headers = headers,
         requestBody = request.data,
+//        requestBody = decoded,
         dataSourceFactory = drmHttpDataSourceFactory,
       ).also {
         logger.i(TAG, "License Response: ${Base64.encodeToString(it, Base64.NO_WRAP)}")

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -33,7 +33,7 @@ import java.util.UUID
 @OptIn(UnstableApi::class)
 class MuxDrmSessionManagerProvider(
   val drmHttpDataSourceFactory: HttpDataSource.Factory,
-  val logger: Logger = createNoLogger(),
+  val logger: Logger,
 ) : DrmSessionManagerProvider {
 
   companion object {
@@ -126,6 +126,8 @@ class MuxDrmCallback(
       "Content-Type" to listOf("application/octet-stream")
     )
 
+    logger.v(TAG, "widevine data: ${Base64.encodeToString(request.data, Base64.NO_WRAP)}")
+
     try {
       return executePost(
         uri,
@@ -136,9 +138,10 @@ class MuxDrmCallback(
         logger.i(TAG, "License Response: ${Base64.encodeToString(it, Base64.NO_WRAP)}")
       }
     } catch (e: InvalidResponseCodeException) {
-      logger.e(TAG, "Provisioning/License Request failed!", e)
+      logger.e(TAG, "Provisioning failed: ${e.responseCode}/${e.responseMessage}", e)
       logger.d(TAG, "Dumping data spec: ${e.dataSpec}")
       logger.d(TAG, "Error Body Bytes: ${Base64.encodeToString(e.responseBody, Base64.NO_WRAP)}")
+      logger.d(TAG, "Error Text: ${e.responseBody.decodeToString()}")
       throw e
     } catch (e: HttpDataSourceException) {
       logger.e(TAG, "Provisioning/License Request failed!", e)

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -1,9 +1,7 @@
 package com.mux.player.media
 
 import android.annotation.SuppressLint
-import android.net.Uri
 import android.util.Base64
-import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -16,11 +14,10 @@ import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.drm.DrmUtil
-import androidx.media3.exoplayer.drm.ExoMediaDrm.ProvisionRequest
 import androidx.media3.exoplayer.drm.ExoMediaDrm.KeyRequest
+import androidx.media3.exoplayer.drm.ExoMediaDrm.ProvisionRequest
 import androidx.media3.exoplayer.drm.FrameworkMediaDrm
 import androidx.media3.exoplayer.drm.MediaDrmCallback
-import com.mux.player.internal.Constants
 import com.mux.player.internal.Logger
 import com.mux.player.internal.createLicenseUri
 import com.mux.player.internal.createNoLogger
@@ -29,7 +26,6 @@ import com.mux.player.internal.getDrmToken
 import com.mux.player.internal.getLicenseUrlHost
 import com.mux.player.internal.getPlaybackDomain
 import com.mux.player.internal.getPlaybackId
-import com.mux.player.media.MediaItems.MUX_VIDEO_DEFAULT_DOMAIN
 import java.io.IOException
 import java.util.UUID
 
@@ -123,31 +119,11 @@ class MuxDrmCallback(
       throw IOException("Mux player does not support scheme: $uuid")
     }
 
-//    val uri = createLicenseUri(playbackId, drmToken, licenseEndpointHost)
     val url = request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data)
     @SuppressLint("UseKtx") // TODO: Probably just include KTX and use that
-    val uri = Uri.parse(request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data))
-//    val uri = Uri.parse(request.defaultUrl)// + "&signedRequest=" + Util.fromUtf8Bytes(request.data))
-//      .buildUpon()
-//      .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
-//      .build()
-    logger.d(TAG, "executeProvisionRequest: license URI is $uri")
-//    val headers = mapOf(
-//      "Content-Type" to listOf("application/octet-stream")
-//    )
-
-//    logger.v(TAG, "widevine data: ${Base64.encodeToString(request.data, Base64.NO_WRAP)}")
-
-//    val decoded = Base64.decode(request.data, Base64.NO_WRAP)
+    logger.d(TAG, "executeProvisionRequest: license URI is $url")
 
     try {
-//      return executePost(
-//        uri,
-//        headers = mapOf(),
-//        requestBody = null,
-////        requestBody = decoded,
-//        dataSourceFactory = drmHttpDataSourceFactory,
-//      )
       return DrmUtil.executePost(
         drmHttpDataSourceFactory.createDataSource(),
         url,

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -132,14 +132,12 @@ class MuxDrmCallback(
       )
     } catch (e: InvalidResponseCodeException) {
       logger.d(TAG, "Dumping data spec: ${e.dataSpec}")
-      logger.d(TAG, "Error Body Bytes: ${Base64.encodeToString(e.responseBody, Base64.NO_WRAP)}")
       throw e
     } catch (e: HttpDataSourceException) {
-      logger.e(TAG, "Provisioning/License Request failed!", e)
-      logger.d(TAG, "Dumping data spec: ${e.dataSpec}")
+      logger.e(TAG, "Provisioning Request failed!", e)
       throw e
     } catch (e: Exception) {
-      logger.e(TAG, "Provisioning/License Request failed!", e)
+      logger.e(TAG, "Provisioning Request failed!", e)
       throw e
     }
   }

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -130,14 +130,9 @@ class MuxDrmCallback(
         null,
         emptyMap()
       )
-        .also {
-        logger.i(TAG, "License Response: ${Base64.encodeToString(it, Base64.NO_WRAP)}")
-      }
     } catch (e: InvalidResponseCodeException) {
-      logger.e(TAG, "Provisioning failed: ${e.responseCode}/${e.responseMessage}", e)
       logger.d(TAG, "Dumping data spec: ${e.dataSpec}")
       logger.d(TAG, "Error Body Bytes: ${Base64.encodeToString(e.responseBody, Base64.NO_WRAP)}")
-      logger.d(TAG, "Error Text: ${e.responseBody.decodeToString()}")
       throw e
     } catch (e: HttpDataSourceException) {
       logger.e(TAG, "Provisioning/License Request failed!", e)

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -120,7 +120,6 @@ class MuxDrmCallback(
     }
 
     val url = request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data)
-    @SuppressLint("UseKtx") // TODO: Probably just include KTX and use that
     logger.d(TAG, "executeProvisionRequest: license URI is $url")
 
     try {

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -13,6 +13,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.CmcdConfiguration
 import com.mux.player.internal.Logger
+import com.mux.player.internal.createLogcatLogger
 import com.mux.player.internal.createNoLogger
 
 /**
@@ -52,7 +53,7 @@ class MuxMediaSourceFactory private constructor(
     ctx: Context,
     dataSourceFactory: DataSource.Factory,
     innerFactory: DefaultMediaSourceFactory = DefaultMediaSourceFactory(ctx),
-  ) : this (ctx, dataSourceFactory, innerFactory, createNoLogger())
+  ) : this (ctx, dataSourceFactory, innerFactory, createLogcatLogger())
 
   init {
     // basics

--- a/library/src/test/java/com/mux/player/media/MuxDrmSessionManagerProviderTests.kt
+++ b/library/src/test/java/com/mux/player/media/MuxDrmSessionManagerProviderTests.kt
@@ -136,7 +136,7 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
     val fakeEndpointHost = "license.fake.endpoint"
     val fakeDrmToken = "fake-drm-token"
     val fakePlaybackId = "fake-playback-id"
-    val fakeRequestData = "--init data".toByteArray() //as in, license request data
+    val fakeRequestData = "--init data".toByteArray()
     val fakeLicenseData = "++license data".toByteArray()
 
     val capturedLicenseReq = slot<DataSpec>()
@@ -175,6 +175,7 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
     }
     val mockProvisionRequest = mockk<ProvisionRequest> {
       every { data } returns fakeRequestData
+      every { defaultUrl } returns "http://fake-url?fakeparam=fakevalue"
     }
     // object under test
     val drmCallback = MuxDrmCallback(
@@ -195,18 +196,12 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
       fakeLicenseData.contentToString(), licenseData.contentToString()
     )
 
-    // Request to license proxy
-    val capturedCertRequestBody = capturedLicenseReq.captured.httpBody
-    val capturedCertRequestHeaders = capturedLicenseReq.captured.httpRequestHeaders
+    // Request to provision endpoint
+    val capturedProvisionRequestUrl = capturedLicenseReq.captured.uri
+    val capturedSignedRequestParam = capturedProvisionRequestUrl.getQueryParameter("signedRequest")
     assertEquals(
-      "Request body from license request should come from provision request",
-      fakeRequestData, capturedCertRequestBody
-    )
-    val capturedContentLen =
-      capturedCertRequestHeaders.mapKeys { it.key.lowercase() }["content-type"]
-    assertEquals(
-      "Request should be application/octet-stream",
-      "application/octet-stream", capturedContentLen
+      "signedRequestParam should be gathered from default URL",
+          fakeRequestData.decodeToString(), capturedSignedRequestParam
     )
   }
 
@@ -229,6 +224,7 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
     }
     val mockProvisionRequest = mockk<ProvisionRequest> {
       every { data } returns fakeRequestData
+      every { defaultUrl } returns "fake-url"
     }
     // object under test
     val drmCallback = MuxDrmCallback(

--- a/library/src/test/java/com/mux/player/media/MuxDrmSessionManagerProviderTests.kt
+++ b/library/src/test/java/com/mux/player/media/MuxDrmSessionManagerProviderTests.kt
@@ -7,6 +7,7 @@ import androidx.media3.exoplayer.drm.DrmSessionManager
 import androidx.media3.exoplayer.drm.ExoMediaDrm.KeyRequest
 import androidx.media3.exoplayer.drm.ExoMediaDrm.ProvisionRequest
 import com.mux.player.AbsRobolectricTest
+import com.mux.player.internal.createNoLogger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -17,6 +18,7 @@ import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.IOException
+import kotlin.math.log
 import kotlin.math.min
 
 class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
@@ -34,7 +36,8 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
       drmToken = "drm token 2"
     )
     val provider = MuxDrmSessionManagerProvider(
-      drmHttpDataSourceFactory = mockk(relaxed = true)
+      drmHttpDataSourceFactory = mockk(relaxed = true),
+      logger = createNoLogger()
     )
 
     val manager1 = provider.get(mediaItem1)
@@ -111,7 +114,8 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
       playbackToken = "playback-token",
     )
     val provider = MuxDrmSessionManagerProvider(
-      drmHttpDataSourceFactory = mockk(relaxed = true)
+      drmHttpDataSourceFactory = mockk(relaxed = true),
+      logger = createNoLogger()
     )
 
     val sessionManagerNoTokens = provider.get(mediaItemNoTokens)


### PR DESCRIPTION
Our implementation of `executeProvisionRequest` was not correct

For Widevine flows, it wasn't called by media3 when we first implemented the DRM feature. A media3 update change this, which exposed the incorrect implementation and broke our DRM playback

We should be calling out to the widevine API for provisioning, and only using our license proxy for key requests