### PR TITLE
Swap MuxPlayer to implement ExoPlayer

### DIFF
--- a/library/src/main/java/com/mux/player/MuxPlayer.kt
+++ b/library/src/main/java/com/mux/player/MuxPlayer.kt
@@ -4,12 +4,11 @@ import android.content.Context
 import android.view.SurfaceView
 import android.view.TextureView
 import androidx.media3.common.MediaItem
-import androidx.media3.common.Player
 import androidx.media3.common.Player.Listener
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.analytics.AnalyticsListener
-import com.mux.player.MuxPlayer.Builder
+import androidx.media3.exoplayer.Renderer
 import com.mux.player.internal.Logger
 import com.mux.player.internal.cache.MuxPlayerCache
 import com.mux.player.internal.createLogcatLogger
@@ -51,7 +50,7 @@ class MuxPlayer private constructor(
   initialCustomerData: CustomerData,
   network: INetworkRequest? = null,
   exoPlayerBinding: ExoPlayerBinding? = null
-) : Player by exoPlayer {
+) : ExoPlayer by exoPlayer {
 
   private var muxStats: MuxStatsSdkMedia3<ExoPlayer>? = null
   private var released: Boolean = false
@@ -65,9 +64,9 @@ class MuxPlayer private constructor(
     muxStats?.updateCustomerData(customerData)
   }
 
-  @Suppress("unused")
-  fun addAnalyticsListener(listener: AnalyticsListener) {
-    exoPlayer.addAnalyticsListener(listener)
+  @UnstableApi
+  override fun getSecondaryRenderer(index: Int): Renderer? {
+    return exoPlayer.getSecondaryRenderer(index)
   }
 
   /**


### PR DESCRIPTION
## Context

The `MuxPlayer` used to implement `ExoPlayer`, but [was changed](https://github.com/muxinc/mux-player-android/pull/74/commits/5551a34d48e0c7b20b278737ea32988c017d4527) to implement `Player`.

I raised a support request asking if the team could revert the change, and was informed by `Ben` that it should be possible.

> I checked in with the team and they let me know that the reason this was changed was to work around some issues that seem to be resolved with some more recent improvements to Kotlin.

I'm raising this PR as an external contributor because:

> We're looking at the possibility of reverting back, but I don't have any timeline yet that I could share for that, a PR would definitely be appreciated, and thank you for raising attention on this!

I couldn't find any contributor documentation, so let me know if I've missed anything

## What prompted the change request?

We're currently trying to integrate the Mux Android player with the IPSOS Dotmetrics SDK.
IPSOS Dotmetrics is the industry standard for measuring user engagement with features, and is integrated by many businesses to drive decisioning and prove value. It already integrates with a number of possible Android players such as `Youtube` and `ExoPlayer`.

To integrate, we need to pass an instance of `ExoPlayer`​ into a Dotmetrics function to register the player.
Unfortunately, the Mux Android player (`MuxPlayer`) doesn't implement the `ExoPlayer`​ child class.
Instead, it implements the `Player`​ class. Dotmetrics requires an `ExoPlayer` instance because it requires access to the following functions from `ExoPlayer`:
`getVideoFormat` and `getAudioFormat`.

These functions differentiate what kind of content is being shown in the player, which feeds into their metrics.

## Testing

- [x] Unit tests
- [x] Automated tests
- [x] Manual verification through the example app