### PR TITLE
Update media3 to v1.9.2 and Mux Data to v1.11.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,11 +5,12 @@ plugins {
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk = 35
+  compileSdk = 36
 
   defaultConfig {
-    minSdk = 21
-    targetSdk = 35
+    minSdk = 23
+    //noinspection EditedTargetSdkVersion
+    targetSdk = 36
     versionCode = 1
     versionName = "1.0"
 
@@ -26,8 +27,8 @@ android {
     }
   }
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
     }
   }
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
   }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,13 @@ android {
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
   }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+  kotlinOptions {
+    jvmTarget = "17"
+  }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,9 +29,6 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,10 +26,6 @@ android {
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
   }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
 }
 
 dependencies {

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -49,8 +49,8 @@ android {
   }
 
   compileOptions {
-  sourceCompatibility = JavaVersion.VERSION_17
-  targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
   }
 }
 

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.android.application'
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk 35
+  compileSdk = 36
 
   defaultConfig {
     applicationId "com.mux.player.media3"
-    minSdkVersion 21
+    minSdkVersion 23
     //noinspection EditedTargetSdkVersion
-    targetSdk 35
+    targetSdk = 36
     versionCode 1
     versionName "1.0"
     multiDexEnabled true

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -49,8 +49,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("com.android.application") version "8.8.2" apply false
+  id("com.android.application") version "8.13.2" apply false
   id("org.jetbrains.kotlin.android") version "2.1.20" apply false
-  id("com.android.library") version "8.8.2" apply false
+  id("com.android.library") version "8.13.2" apply false
   id("com.mux.gradle.android.mux-android-distribution") version "1.3.0" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -84,7 +84,6 @@ dependencies {
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"
   api "androidx.media3:media3-exoplayer-hls:${media3Version}"
-//  api "androidx.media3:media3-exoplayer-ima:${media3Version}"
   api "androidx.media3:media3-cast:${media3Version}"
 
   api("com.mux.stats.sdk.muxstats:data-media3-$muxDataVariant:${muxDataVersion}")

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -91,10 +91,10 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.1.5'
-  testImplementation "io.mockk:mockk:1.12.3"
-  testImplementation 'org.robolectric:robolectric:4.10.3'
+  testImplementation 'androidx.test.ext:junit:1.3.0'
+  testImplementation "io.mockk:mockk:1.14.9"
+  testImplementation 'org.robolectric:robolectric:4.16.1'
 
-  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
   namespace 'com.mux.player'
-  compileSdk 35
+  compileSdk = 36
 
   defaultConfig {
-    minSdk 21
+    minSdk = 23
     //noinspection EditedTargetSdkVersion
-    targetSdk 35
+    targetSdk = 36
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -77,14 +77,14 @@ muxDistribution {
 
 dependencies {
 
-  def media3Version = "1.6.1"
-  def muxDataVariant = "at_1_6"
-  def muxDataVersion = "1.8.0"
+  def media3Version = "1.9.2"
+  def muxDataVariant = "at_1_9"
+  def muxDataVersion = "1.11.1"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"
   api "androidx.media3:media3-exoplayer-hls:${media3Version}"
-  api "androidx.media3:media3-exoplayer-ima:${media3Version}"
+//  api "androidx.media3:media3-exoplayer-ima:${media3Version}"
   api "androidx.media3:media3-cast:${media3Version}"
 
   api("com.mux.stats.sdk.muxstats:data-media3-$muxDataVariant:${muxDataVersion}")

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -1,6 +1,7 @@
 package com.mux.player.media
 
 import android.annotation.SuppressLint
+import android.media.MediaDrm
 import android.util.Base64
 import androidx.annotation.OptIn
 import androidx.media3.common.C
@@ -113,7 +114,7 @@ class MuxDrmCallback(
   override fun executeProvisionRequest(
     uuid: UUID,
     request: ProvisionRequest
-  ): ByteArray {
+  ): MediaDrmCallback.Response {
     val widevine = uuid == C.WIDEVINE_UUID;
     if (!widevine) {
       throw IOException("Mux player does not support scheme: $uuid")
@@ -125,8 +126,7 @@ class MuxDrmCallback(
     try {
       return DrmUtil.executePost(
         drmHttpDataSourceFactory.createDataSource(),
-        url,
-        null,
+        url, null,
         emptyMap()
       )
     } catch (e: InvalidResponseCodeException) {
@@ -146,7 +146,7 @@ class MuxDrmCallback(
   override fun executeKeyRequest(
     uuid: UUID,
     request: KeyRequest
-  ): ByteArray {
+  ): MediaDrmCallback.Response {
     val widevine = uuid == C.WIDEVINE_UUID
     if (!widevine) {
       throw IOException("Mux player does not support scheme: $uuid")
@@ -159,12 +159,12 @@ class MuxDrmCallback(
     logger.d(TAG, "Key Request URI is $url")
 
     try {
-      return executePost(
+      return MediaDrmCallback.Response(executePost(
         uri = url,
         headers = headers,
         requestBody = request.data,
         dataSourceFactory = drmHttpDataSourceFactory,
-      )
+      ))
     } catch (e: InvalidResponseCodeException) {
       logger.e(TAG, "key request failed!", e)
       logger.d(TAG, "Failed data spec: ${e.dataSpec}")

--- a/library/src/test/java/com/mux/player/media/MuxDrmSessionManagerProviderTests.kt
+++ b/library/src/test/java/com/mux/player/media/MuxDrmSessionManagerProviderTests.kt
@@ -193,7 +193,7 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
     // Data to CDM
     assertEquals(
       "license data should be returned to caller",
-      fakeLicenseData.contentToString(), licenseData.contentToString()
+      fakeLicenseData.contentToString(), licenseData.data.contentToString()
     )
 
     // Request to provision endpoint
@@ -306,7 +306,7 @@ class MuxDrmSessionManagerProviderTests : AbsRobolectricTest() {
     // Data to CDM
     assertEquals(
       "license data should be returned to caller",
-      fakeKeyData.contentToString(), keyData.contentToString()
+      fakeKeyData.contentToString(), keyData.data.contentToString()
     )
 
     // Request to license proxy


### PR DESCRIPTION
What it says in the title

Also includes some routine tooling updates, for IDE support

This PR also removes the `media3-ima` library from Mux Player. The latest IMA updates require hassling with the build tools a little in order to use, and I don't want to require that people do it. According to Videoz data, literally no one is using Mux Player with ads at all, so this should be perfectly safe to just do.