### PR TITLE
Releases/v1.5.4

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,9 +77,9 @@ muxDistribution {
 
 dependencies {
 
-  def media3Version = "1.9.2"
-  def muxDataVariant = "at_1_9"
-  def muxDataVersion = "1.11.1"
+  def media3Version = "1.10.0"
+  def muxDataVariant = "at_1_10"
+  def muxDataVersion = "1.11.2"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"


### PR DESCRIPTION
## Updates
* Update androidx.media3: 1.9.2 → 1.10.0
*  mux data variant: at_1_9 → at_1_10 (required for media3 1.10.x)
*  mux data SDK: 1.11.1 → 1.11.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core playback dependencies (`androidx.media3` and Mux Data Media3 integration), which can introduce behavior or API changes at runtime even though the diff is limited to version bumps.
> 
> **Overview**
> Bumps `androidx.media3` from `1.9.2` to `1.10.0` across the library.
> 
> Updates the Mux Data Media3 dependency to the matching `at_1_10` variant and bumps the Mux Data SDK from `1.11.1` to `1.11.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1a6960e6c91bb42a7ac9c8706a406d45307741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Improvements

* chore: update media3 to 1.10.0 and mux data SDK to 1.11.2



Co-authored-by: Emily Dixon <edixon@mux.com>