### PR TITLE
Update Gradle Plugin to 9.x, Distrubution Plugin to 1.4, and Android SDK Version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("com.android.application")
-//  id("org.jetbrains.kotlin.android")
 }
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     minSdk = 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 36
+    targetSdk = 37
     versionCode = 1
     versionName = "1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk = 37
+  compileSdk = 36
 
   defaultConfig {
     minSdk = 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 37
+    targetSdk = 36
     versionCode = 1
     versionName = "1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,10 +29,6 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-
-//  kotlinOptions {
-//    jvmTarget = "17"
-//  }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.application")
-  id("org.jetbrains.kotlin.android")
+//  id("org.jetbrains.kotlin.android")
 }
 
 android {
@@ -30,9 +30,10 @@ android {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
   }
-  kotlinOptions {
-    jvmTarget = "17"
-  }
+
+//  kotlinOptions {
+//    jvmTarget = "17"
+//  }
 }
 
 dependencies {

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.android.application'
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk = 37
+  compileSdk = 36
 
   defaultConfig {
     applicationId "com.mux.player.media3"
     minSdkVersion 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 37
+    targetSdk = 36
     versionCode 1
     versionName "1.0"
     multiDexEnabled true

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.android.application'
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     applicationId "com.mux.player.media3"
     minSdkVersion 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 36
+    targetSdk = 37
     versionCode 1
     versionName "1.0"
     multiDexEnabled true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.application") version "9.2.1" apply false
-  id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+//  id("org.jetbrains.kotlin.android") version "2.2.10" apply false
   id("com.android.library") version "9.2.1" apply false
-  id("com.mux.gradle.android.mux-android-distribution") version "1.4.0-ng2" apply false
+  id("com.mux.gradle.android.mux-android-distribution") version "1.4.0-ng3" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,5 +2,5 @@ plugins {
   id("com.android.application") version "9.2.1" apply false
 //  id("org.jetbrains.kotlin.android") version "2.2.10" apply false
   id("com.android.library") version "9.2.1" apply false
-  id("com.mux.gradle.android.mux-android-distribution") version "1.4.0-ng3" apply false
+  id("com.mux.gradle.android.mux-android-distribution") version "1.4.0-ng4" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.application") version "9.2.1" apply false
-//  id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+  id("org.jetbrains.kotlin.android") version "2.2.10" apply false
   id("com.android.library") version "9.2.1" apply false
   id("com.mux.gradle.android.mux-android-distribution") version "1.4.0" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,5 +2,5 @@ plugins {
   id("com.android.application") version "9.2.1" apply false
 //  id("org.jetbrains.kotlin.android") version "2.2.10" apply false
   id("com.android.library") version "9.2.1" apply false
-  id("com.mux.gradle.android.mux-android-distribution") version "1.4.0-ng4" apply false
+  id("com.mux.gradle.android.mux-android-distribution") version "1.4.0" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("com.android.application") version "8.13.2" apply false
-  id("org.jetbrains.kotlin.android") version "2.1.20" apply false
-  id("com.android.library") version "8.13.2" apply false
-  id("com.mux.gradle.android.mux-android-distribution") version "1.3.0" apply false
+  id("com.android.application") version "9.2.1" apply false
+  id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+  id("com.android.library") version "9.2.1" apply false
+  id("com.mux.gradle.android.mux-android-distribution") version "1.4.0-ng2" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,13 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,13 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-#android.defaults.buildfeatures.resvalues=true
-#android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-#android.enableAppCompileTimeRClass=false
-#android.usesSdkInManifest.disallowed=false
-#android.uniquePackageNames=false
-#android.dependency.useConstraints=true
-#android.r8.strictFullModeForKeepRules=false
-#android.r8.optimizedResourceShrinking=false
-#android.builtInKotlin=false
-#android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,13 +21,13 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
-android.dependency.useConstraints=true
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
+#android.defaults.buildfeatures.resvalues=true
+#android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+#android.enableAppCompileTimeRClass=false
+#android.usesSdkInManifest.disallowed=false
+#android.uniquePackageNames=false
+#android.dependency.useConstraints=true
+#android.r8.strictFullModeForKeepRules=false
+#android.r8.optimizedResourceShrinking=false
+#android.builtInKotlin=false
+#android.newDsl=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
+#Fri Jun 12 13:05:29 PDT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
-networkTimeout=10000
-validateDistributionUrl=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 // TODO: Update this to kotlin after updating the distribution plugin extension
 plugins {
   id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
+//  id 'org.jetbrains.kotlin.android'
   id 'com.mux.gradle.android.mux-android-distribution'
 }
 
@@ -11,7 +11,6 @@ android {
 
   defaultConfig {
     minSdk = 23
-    //noinspection EditedTargetSdkVersion
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -28,15 +27,6 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
-  }
-  kotlinOptions {
-    jvmTarget = '1.8'
-  }
-  lint {
-    targetSdk 37
-  }
-  testOptions {
-    targetSdk 37
   }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
   namespace 'com.mux.player'
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     minSdk = 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 36
+    targetSdk = 37
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -88,11 +88,11 @@ dependencies {
 
   api("com.mux.stats.sdk.muxstats:data-media3-$muxDataVariant:${muxDataVersion}")
 
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0"
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.3.0'
-  testImplementation "io.mockk:mockk:1.14.9"
+  testImplementation "io.mockk:mockk:1.14.11"
   testImplementation 'org.robolectric:robolectric:4.16.1'
 
   androidTestImplementation 'androidx.test.ext:junit:1.3.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,6 @@
 // TODO: Update this to kotlin after updating the distribution plugin extension
 plugins {
   id 'com.android.library'
-//  id 'org.jetbrains.kotlin.android'
   id 'com.mux.gradle.android.mux-android-distribution'
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,9 +77,9 @@ muxDistribution {
 
 dependencies {
 
-  def media3Version = "1.9.2"
-  def muxDataVariant = "at_1_9"
-  def muxDataVersion = "1.11.1"
+  def media3Version = "1.10.1"
+  def muxDataVariant = "at_1_10"
+  def muxDataVersion = "1.12.0"
   api "androidx.media3:media3-common:${media3Version}"
   api "androidx.media3:media3-exoplayer:${media3Version}"
   api "androidx.media3:media3-ui:${media3Version}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,12 +7,11 @@ plugins {
 
 android {
   namespace 'com.mux.player'
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     minSdk = 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 36
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -32,6 +31,12 @@ android {
   }
   kotlinOptions {
     jvmTarget = '1.8'
+  }
+  lint {
+    targetSdk 37
+  }
+  testOptions {
+    targetSdk 37
   }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
   namespace 'com.mux.player'
-  compileSdk = 37
+  compileSdk = 36
 
   defaultConfig {
     minSdk = 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 37
+    targetSdk = 36
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Major AGP/Gradle version jumps can break CI and publishing until validated, but changes are limited to build scripts and dependency versions with no application logic edits.
> 
> **Overview**
> Upgrades the Android build toolchain to **AGP 9.2.1**, **Gradle 9.5.1**, **Kotlin 2.2.10**, and **Mux android distribution plugin 1.4.0**, and bumps **compileSdk/targetSdk** from 36 to **37** in the app, automated tests, and library modules.
> 
> Aligns modules with AGP 9 conventions by **dropping the per-module `org.jetbrains.kotlin.android` plugin** and **`kotlinOptions` / `jvmTarget`** blocks from `app` and `library` (Kotlin remains on the root classpath). The library module also drops **`targetSdk`** from `defaultConfig` and refreshes runtime deps: **Media3 1.10.1**, **Mux Data 1.12.0**, **kotlinx-coroutines 1.11.0**, and **MockK 1.14.11**.
> 
> The Gradle wrapper switches to the **9.5.1 bin** distribution and no longer sets `networkTimeout` / `validateDistributionUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c3149b79f5f0d18ec6162309cd033750f02465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->