### PR TITLE
NAT-465: Meter external bandwidth when smart caching is enabled

### DIFF
--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -120,7 +120,7 @@ class MuxDataSource private constructor(
 
     val upstreamBytes = openAndInitFromRemote(revalidateSpec, revalidatingDataSource)
 
-    return if (upstream.responseCode != 304) {
+    return if (revalidatingDataSource.responseCode != 304) {
       // Entry wasn't valid anymore, but we did a GET so the body's ready to read and we're done
 
       // todo - we *could* delete the row here, but consider that stale items can be used if
@@ -130,7 +130,6 @@ class MuxDataSource private constructor(
       upstreamBytes
     } else {
       // Entry was still valid, so read from cache instead
-      upstream.close()
       revalidatingDataSource.close()
 
       openAndInitFromCache(readHandle)

--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -130,6 +130,7 @@ class MuxDataSource private constructor(
       upstreamBytes
     } else {
       // Entry was still valid, so read from cache instead
+      upstream.close()
       revalidatingDataSource.close()
 
       openAndInitFromCache(readHandle)

--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -12,6 +12,7 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.HttpDataSource.HttpDataSourceException
 import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
+import androidx.media3.datasource.TransferListener
 import com.google.common.net.HttpHeaders
 import com.mux.player.internal.cache.MuxPlayerCache
 import com.mux.player.internal.cache.MuxPlayerCache.ReadHandle
@@ -24,9 +25,9 @@ import java.net.URL
 
 @OptIn(UnstableApi::class)
 class MuxDataSource private constructor(
-  private val upstreamSrcFac: HttpDataSource.Factory,
+  upstreamSrcFac: HttpDataSource.Factory,
   private val muxPlayerCache: MuxPlayerCache,
-) : BaseDataSource(false) {
+) : DataSource {
 
   /**
    * Creates a new instance of [MuxDataSource]. The upstream data source will be invoked for any
@@ -48,7 +49,9 @@ class MuxDataSource private constructor(
   private var dataSpec: DataSpec? = null
 
   private var respondingFromCache: Boolean = false
-  private var upstream: HttpDataSource? = null // only present if we need to request something
+  private val upstream = upstreamSrcFac.createDataSource()
+  private val revalidatingDataSource = RevalidatingDataSource.Factory().createDataSource()
+
   private var cacheReader: ReadHandle? = null
   private var cacheWriter: WriteHandle? = null
 
@@ -73,6 +76,11 @@ class MuxDataSource private constructor(
     }
   }
 
+  override fun addTransferListener(transferListener: TransferListener) {
+    upstream.addTransferListener(transferListener)
+    revalidatingDataSource.addTransferListener(transferListener)
+  }
+
   override fun open(dataSpec: DataSpec): Long {
     this.dataSpec = dataSpec;
 
@@ -81,7 +89,7 @@ class MuxDataSource private constructor(
 
     return if (readHandle == null) {
       // cache miss
-      openAndInitFromRemote(dataSpec, upstreamSrcFac)
+      openAndInitFromRemote(dataSpec, upstream)
     } else if (muxPlayerCache.revalidateRequired(nowUtc, readHandle)) {
       // need to revalidate
       openAndInitRevalidating(dataSpec, readHandle)
@@ -96,7 +104,8 @@ class MuxDataSource private constructor(
   override fun close() {
     cacheReader?.close()
     cacheWriter?.close()
-    upstream?.close()
+    upstream.close()
+    revalidatingDataSource.close()
   }
 
   private fun openAndInitRevalidating(dataSpec: DataSpec, readHandle: ReadHandle): Long {
@@ -109,8 +118,7 @@ class MuxDataSource private constructor(
       .setHttpRequestHeaders(revalidateRequestHeaders)
       .build()
 
-    val upstreamBytes = openAndInitFromRemote(revalidateSpec, RevalidatingDataSource.Factory())
-    val upstream = this.upstream!! // set by initAndOpenUpstream
+    val upstreamBytes = openAndInitFromRemote(revalidateSpec, revalidatingDataSource)
 
     return if (upstream.responseCode != 304) {
       // Entry wasn't valid anymore, but we did a GET so the body's ready to read and we're done
@@ -123,21 +131,18 @@ class MuxDataSource private constructor(
     } else {
       // Entry was still valid, so read from cache instead
       upstream.close()
-      this.upstream = null
+      revalidatingDataSource.close()
 
       openAndInitFromCache(readHandle)
     }
   }
 
-  private fun openAndInitFromRemote(dataSpec: DataSpec, fac: HttpDataSource.Factory): Long {
+  private fun openAndInitFromRemote(dataSpec: DataSpec, remoteDataSrc: HttpDataSource): Long {
     respondingFromCache = false
-    val upstream = fac.createDataSource()
-
-    this.upstream = upstream
-    val available = upstream.open(dataSpec)
+    val available = remoteDataSrc.open(dataSpec)
     cacheWriter = muxPlayerCache.startWriting(
       dataSpec.uri.toString(),
-      upstream.responseHeaders,
+      remoteDataSrc.responseHeaders,
     )
     return available
   }

--- a/library/src/main/java/com/mux/player/media/MuxDataSource.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDataSource.kt
@@ -25,7 +25,7 @@ import java.net.URL
 
 @OptIn(UnstableApi::class)
 class MuxDataSource private constructor(
-  upstreamSrcFac: HttpDataSource.Factory,
+  private val upstreamSrcFac: HttpDataSource.Factory,
   private val muxPlayerCache: MuxPlayerCache,
 ) : DataSource {
 
@@ -49,11 +49,11 @@ class MuxDataSource private constructor(
   private var dataSpec: DataSpec? = null
 
   private var respondingFromCache: Boolean = false
-  private val upstream = upstreamSrcFac.createDataSource()
-  private val revalidatingDataSource = RevalidatingDataSource.Factory().createDataSource()
-
+  private var upstream: HttpDataSource? = null // only present if we need to request something
   private var cacheReader: ReadHandle? = null
   private var cacheWriter: WriteHandle? = null
+
+  private val transferListeners = mutableListOf<TransferListener>()
 
   override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
     return if (respondingFromCache) {
@@ -77,8 +77,7 @@ class MuxDataSource private constructor(
   }
 
   override fun addTransferListener(transferListener: TransferListener) {
-    upstream.addTransferListener(transferListener)
-    revalidatingDataSource.addTransferListener(transferListener)
+    transferListeners += transferListener
   }
 
   override fun open(dataSpec: DataSpec): Long {
@@ -89,7 +88,7 @@ class MuxDataSource private constructor(
 
     return if (readHandle == null) {
       // cache miss
-      openAndInitFromRemote(dataSpec, upstream)
+      openAndInitFromRemote(dataSpec, upstreamSrcFac)
     } else if (muxPlayerCache.revalidateRequired(nowUtc, readHandle)) {
       // need to revalidate
       openAndInitRevalidating(dataSpec, readHandle)
@@ -104,8 +103,7 @@ class MuxDataSource private constructor(
   override fun close() {
     cacheReader?.close()
     cacheWriter?.close()
-    upstream.close()
-    revalidatingDataSource.close()
+    upstream?.close()
   }
 
   private fun openAndInitRevalidating(dataSpec: DataSpec, readHandle: ReadHandle): Long {
@@ -118,9 +116,10 @@ class MuxDataSource private constructor(
       .setHttpRequestHeaders(revalidateRequestHeaders)
       .build()
 
-    val upstreamBytes = openAndInitFromRemote(revalidateSpec, revalidatingDataSource)
+    val upstreamBytes = openAndInitFromRemote(revalidateSpec, RevalidatingDataSource.Factory())
+    val upstream = this.upstream!! // set by openAndInitFromRemote
 
-    return if (revalidatingDataSource.responseCode != 304) {
+    return if (upstream.responseCode != 304) {
       // Entry wasn't valid anymore, but we did a GET so the body's ready to read and we're done
 
       // todo - we *could* delete the row here, but consider that stale items can be used if
@@ -131,18 +130,21 @@ class MuxDataSource private constructor(
     } else {
       // Entry was still valid, so read from cache instead
       upstream.close()
-      revalidatingDataSource.close()
+      this.upstream = null
 
       openAndInitFromCache(readHandle)
     }
   }
 
-  private fun openAndInitFromRemote(dataSpec: DataSpec, remoteDataSrc: HttpDataSource): Long {
+  private fun openAndInitFromRemote(dataSpec: DataSpec, fac: HttpDataSource.Factory): Long {
     respondingFromCache = false
-    val available = remoteDataSrc.open(dataSpec)
+    val upstream = createDataSource(fac)
+
+    this.upstream = upstream
+    val available = upstream.open(dataSpec)
     cacheWriter = muxPlayerCache.startWriting(
       dataSpec.uri.toString(),
-      remoteDataSrc.responseHeaders,
+      upstream.responseHeaders,
     )
     return available
   }
@@ -151,6 +153,16 @@ class MuxDataSource private constructor(
     respondingFromCache = true
     this.cacheReader = readHandle
     return readHandle.fileSize
+  }
+
+  /**
+   * Creates a delegate [HttpDataSource] from the given factory, transitively adding all of our
+   * registered [TransferListener]s so that bandwidth from the delegate is still metered.
+   */
+  private fun createDataSource(fac: HttpDataSource.Factory): HttpDataSource {
+    val dataSource = fac.createDataSource()
+    transferListeners.forEach { dataSource.addTransferListener(it) }
+    return dataSource
   }
 }
 


### PR DESCRIPTION
Based on #45, but with a better implementation.

This was de-prioritized for a long time. No one was complaining, but I wanted to get it working after our recent discussion about this topic

~~Because of the way `TransferListener`s are added, we have to pre-create our delegate data sources. This is lame but not costly. `DataSource` doesn't do any I/O until you call `open()` on it, which we only do when we really use them. This is also the way the default `CacheDataSource` handles its delegate upstream sources, so it must be fine.~~

This is simpler to read and better when the data sources are created lazily. All we need to do to enable bandwidth metering again is to add `TransferListener`s to the delegate data sources (the bandwidth meter is/has a transfer listener for metering purposes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to the caching data-source wrapper; follows the same delegate-listener pattern as Media3’s CacheDataSource with no I/O until open().
> 
> **Overview**
> Fixes **missing external bandwidth metrics** when smart caching is enabled by making `MuxDataSource` honor Media3 `TransferListener` registration and **forward those listeners** to the delegate `HttpDataSource` used for network fetches (cache misses and revalidation).
> 
> `MuxDataSource` now implements `DataSource` directly (instead of inheriting `BaseDataSource`), keeps registered listeners, and applies them in a new `createDataSource` helper whenever an upstream HTTP source is created—so ExoPlayer’s bandwidth metering still sees bytes transferred over the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1ed253e2a8986218a32642981677d7803e41ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->