### PR TITLE
Ignore Gradle Daemon properties (IDE-generated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .gradle/
 build/
 
+# daemon jvm properties, set by IDE
+gradle/gradle-daemon-jvm.properties
+
 # Local configuration file (sdk path, etc)
 local.properties
 


### PR DESCRIPTION
I guess we're running a gradle daemon these days to cut down on build time, instead of starting a new gradle process for every build

That's fine I guess. Not concerned. Let Studio add whatever files it needs in order to facilitate that, we don't need to check them in if it's gonna generate them on-demand, and/or possibly change them in later versions. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`; no runtime, build logic, or application behavior changes.
> 
> **Overview**
> Adds **`gradle/gradle-daemon-jvm.properties`** to **`.gitignore`** so Android Studio / Gradle daemon JVM settings are not committed.
> 
> These files are generated on demand for faster local builds and may change with IDE or Gradle versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2145b50104133a0a677840153929818d2bbe4c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->