### PR TITLE
Add ai-review caller workflow (observe-only)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -28,6 +28,13 @@ jobs:
   ai-review-observe:
     name: ai-review (observe)
     runs-on: ubuntu-latest
+    # Fork PRs don't receive repo/org secrets (GitHub withholds them from forks
+    # by design), so REVIEW_TOOL_TOKEN would be empty and the tool checkout would
+    # 403. Skip the job entirely on fork PRs instead of letting it fail — a
+    # skipped job shows as neutral, never a red/blocking check, which keeps this
+    # true to its observe-only intent. Same-repo PRs (the SDK team's own branches)
+    # run normally.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check out review tool
         uses: actions/checkout@v4

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,15 +1,84 @@
+# Observe-only AI review. Inlines the steps from muxinc/code-review-analysis's
+# reusable workflow (.github/workflows/ai-review-observe.yml) instead of calling
+# it with `uses:` — GitHub does not allow a public repo to consume a reusable
+# workflow from a private repo via org-level Actions access, and this repo is
+# public while the tool repo is (for now) private. Checking the tool repo out
+# with a token sidesteps that restriction. If code-review-analysis is ever made
+# internal/public, this can revert to a thin `uses:` caller.
+#
+# This is OBSERVE-ONLY: it posts a comment + informational label and logs the
+# ruling. It does not block merges and creates no ruleset.
+
 name: ai-review
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
 permissions:
   contents: read
   pull-requests: write
   issues: write
+
 concurrency:
   group: ai-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
+
 jobs:
-  review:
-    uses: muxinc/code-review-analysis/.github/workflows/ai-review-observe.yml@main
-    secrets: inherit
+  ai-review-observe:
+    name: ai-review (observe)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out review tool
+        uses: actions/checkout@v4
+        with:
+          repository: muxinc/code-review-analysis
+          ref: main
+          token: ${{ secrets.REVIEW_TOOL_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Classify PR (post comment + label, observe-only)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python -m live.classify \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number }}" \
+            --live-config "live/config.native-sdk.yml" \
+            --apply --observe \
+            > result.json
+          cat result.json
+
+      - name: Render job summary
+        run: |
+          {
+            echo "## AI Review — observe-only"
+            echo ""
+            echo "PR [#$(jq -r '.pr' result.json)]($(jq -r '.url' result.json)) — **$(jq -r '.band' result.json)**"
+            echo ""
+            echo "| Layer | Result |"
+            echo "|---|---|"
+            echo "| Band (final) | \`$(jq -r '.label' result.json)\` |"
+            echo "| Route | $(jq -r '.route' result.json) |"
+            echo "| Engine score | $(jq -r '.engine_score' result.json) |"
+            echo "| Learned score | $(jq -r '.learned_score' result.json) |"
+            echo "| LLM judge | $(jq -r '.llm_score // "n/a"' result.json) |"
+            echo ""
+            echo "_Informational only — nothing is enforced._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record ruling to central log
+        env:
+          GH_TOKEN: ${{ secrets.REVIEW_TOOL_TOKEN }}
+          LOG_REPO: muxinc/code-review-analysis
+          LOG_BRANCH: rulings-log
+          LOG_PATH: rulings.jsonl
+        run: |
+          python -m live.record_ruling --result-file result.json

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,15 @@
+name: ai-review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  review:
+    uses: muxinc/code-review-analysis/.github/workflows/ai-review-observe.yml@main
+    secrets: inherit


### PR DESCRIPTION
Wires pull_request events to the reusable observe-only AI review workflow in muxinc/code-review-analysis. Posts one informational comment + review:* label per PR, appends a ruling to rulings.jsonl. No enforcement, no required checks, no ruleset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces CI that consumes org secrets (tool checkout, Anthropic) and writes to PRs and an external rulings log, though it is non-blocking and fork PRs are excluded.
> 
> **Overview**
> Adds a new **`ai-review`** GitHub Actions workflow that runs on PR **opened**, **synchronize**, and **reopened** events.
> 
> Because this public repo cannot call a reusable workflow from the private **`muxinc/code-review-analysis`** repo, the workflow **inlines** that tool’s steps: checkout the tool with **`REVIEW_TOOL_TOKEN`**, run Python **`live.classify`** with **`live/config.native-sdk.yml`** and **`--apply --observe`**, then **`live.record_ruling`** to append to **`rulings.jsonl`** on the tool repo’s **`rulings-log`** branch. The job posts an informational PR comment and label, writes a step summary table (band, route, scores), and explicitly does **not** enforce merges or rulesets.
> 
> **Fork PRs are skipped** (`head.repo` must match the current repository) so missing fork secrets do not produce failing checks—skipped jobs stay neutral for observe-only behavior. Concurrency cancels in-progress runs per PR number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6eccb91669b5964e28b57f75f397e134a288d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->