### PR TITLE
NAT-454: Offline Download API

### DIFF
--- a/library/src/main/java/com/mux/player/media/MediaItems.kt
+++ b/library/src/main/java/com/mux/player/media/MediaItems.kt
@@ -179,6 +179,12 @@ object MediaItems {
       )
   }
 
+  fun forMuxDownload(playbackId: String): MediaItem {
+    // stubbed for now. Will create a MediaItem that `MuxDataSourceFactory` knows play from disk
+    //  (no need to do anything async just to get the MediaItem)
+    TODO("stub for documentation's sake")
+  }
+
   private fun createPlaybackUrl(
     playbackId: String,
     domain: String = MUX_VIDEO_DEFAULT_DOMAIN,

--- a/library/src/main/java/com/mux/player/offline/MuxDownload.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownload.kt
@@ -3,13 +3,7 @@ package com.mux.player.offline
 /**
  * A **snapshot** of a single Mux offline download, keyed by its playback ID.
  *
- * Instances are immutable point-in-time readings. The [state] and progress values
- * ([percentDownloaded], [bytesDownloaded], [totalBytes]) reflect the download **at the moment the
- * snapshot was created** and are *never* updated afterward. To observe changes over time, register a
- * [MuxDownloadManager.Listener] with [MuxDownloadManager.addListener] (each callback delivers a fresh
- * snapshot) or re-query [MuxDownloadManager.getDownload]/[MuxDownloadManager.allDownloads].
- *
- * You don't create these yourself; the SDK hands them to you from [MuxDownloadManager].
+ * You don't create these yourself; the SDK returns them from [MuxDownloadManager].
  */
 @ConsistentCopyVisibility
 data class MuxDownload internal constructor(
@@ -19,7 +13,7 @@ data class MuxDownload internal constructor(
   val state: State,
   /**
    * How much of the download has completed, in the range `0.0..100.0`, or `-1f`
-   * ([androidx.media3.common.C.PERCENTAGE_UNSET]) if not yet known. Snapshot only — not live.
+   * ([androidx.media3.common.C.PERCENTAGE_UNSET]) if not yet known.
    */
   val percentDownloaded: Float,
   /** Bytes downloaded to disk so far at the time of this snapshot. */
@@ -36,15 +30,14 @@ data class MuxDownload internal constructor(
    *
    * Beyond the states Media3's `DownloadManager` reports, this adds [STARTING] to cover the work Mux
    * does *before* a download is handed to the `DownloadManager`: fetching the HLS manifests and, for
-   * DRM content, acquiring the offline license. During that window there is no `DownloadManager`
-   * entry yet, so [STARTING] is the only signal that a download is in flight.
+   * DRM content, acquiring the offline license.
    */
   enum class State {
     /**
      * Mux is preparing the download — fetching manifests and (for DRM) acquiring the offline
-     * license — but it has **not** been queued on the `DownloadManager` yet. This precedes [QUEUED].
-     * If preparation fails, the next snapshot is [FAILED]; there is no `DownloadManager` entry for a
-     * download that never left this state.
+     * license. This precedes [QUEUED].
+     * If preparation fails, the next snapshot is [FAILED]; there is no `DownloadManager` entry for
+     * a download that never left this state.
      */
     STARTING,
 

--- a/library/src/main/java/com/mux/player/offline/MuxDownload.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownload.kt
@@ -6,12 +6,13 @@ package com.mux.player.offline
  * Instances are immutable point-in-time readings. The [state] and progress values
  * ([percentDownloaded], [bytesDownloaded], [totalBytes]) reflect the download **at the moment the
  * snapshot was created** and are *never* updated afterward. To observe changes over time, register a
- * [Listener] with [MuxOfflineDownloads.addListener] (each callback delivers a fresh snapshot) or
- * re-query [MuxOfflineDownloads.getDownload]/[MuxOfflineDownloads.allDownloads].
+ * [MuxDownloadManager.Listener] with [MuxDownloadManager.addListener] (each callback delivers a fresh
+ * snapshot) or re-query [MuxDownloadManager.getDownload]/[MuxDownloadManager.allDownloads].
  *
- * You don't create these yourself; the SDK hands them to you from [MuxOfflineDownloads].
+ * You don't create these yourself; the SDK hands them to you from [MuxDownloadManager].
  */
-class MuxDownload internal constructor(
+@ConsistentCopyVisibility
+data class MuxDownload internal constructor(
   /** The Mux playback ID this download was started for. Stable for the life of the download. */
   val playbackId: String,
   /** The download's state at the time this snapshot was taken. See [State]. */
@@ -56,7 +57,10 @@ class MuxDownload internal constructor(
     /** Fully downloaded and available for offline playback. */
     COMPLETED,
 
-    /** The download failed. When reported via [Listener.onDownloadChanged], the cause is provided. */
+    /**
+     * The download failed. When reported via [MuxDownloadManager.Listener.onDownloadChanged], the
+     * cause is provided.
+     */
     FAILED,
 
     /** The download is being removed and its media deleted. */
@@ -64,60 +68,5 @@ class MuxDownload internal constructor(
 
     /** Stopped (e.g. paused) and will not progress until resumed. */
     STOPPED,
-  }
-
-  /**
-   * Observes offline-download progress and lifecycle changes.
-   *
-   * Callbacks are driven by Media3's `DownloadManager.Listener` (plus Mux's [State.STARTING] phase),
-   * translated to deliver [MuxDownload] snapshots instead of raw Media3 types. All callbacks are
-   * delivered on the `DownloadManager`'s application looper (the main thread in normal use).
-   *
-   * Register with [MuxOfflineDownloads.addListener] and unregister with
-   * [MuxOfflineDownloads.removeListener].
-   */
-  interface Listener {
-    /**
-     * Called whenever a download's [state][State] or progress changes, including the initial
-     * [State.STARTING] snapshot emitted by [MuxOfflineDownloads.startDownload].
-     *
-     * @param download a fresh snapshot of the download at this transition.
-     * @param error the cause when [download].state is [State.FAILED], otherwise `null`.
-     */
-    fun onDownloadChanged(download: MuxDownload, error: Throwable?)
-
-    /**
-     * Called when a download has been removed. [download] is the last snapshot before removal.
-     */
-    fun onDownloadRemoved(download: MuxDownload) {}
-
-    /**
-     * Called when there is a change in whether one or more downloads are stalled *solely* because
-     * the `DownloadManager`'s requirements (e.g. network connectivity) are not met.
-     */
-    fun onWaitingForRequirementsChanged(waitingForRequirements: Boolean) {}
-  }
-
-  override fun toString(): String =
-    "MuxDownload(playbackId='$playbackId', state=$state, percentDownloaded=$percentDownloaded, " +
-      "bytesDownloaded=$bytesDownloaded, totalBytes=$totalBytes)"
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other !is MuxDownload) return false
-    return playbackId == other.playbackId
-      && state == other.state
-      && percentDownloaded == other.percentDownloaded
-      && bytesDownloaded == other.bytesDownloaded
-      && totalBytes == other.totalBytes
-  }
-
-  override fun hashCode(): Int {
-    var result = playbackId.hashCode()
-    result = 31 * result + state.hashCode()
-    result = 31 * result + percentDownloaded.hashCode()
-    result = 31 * result + bytesDownloaded.hashCode()
-    result = 31 * result + totalBytes.hashCode()
-    return result
   }
 }

--- a/library/src/main/java/com/mux/player/offline/MuxDownload.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownload.kt
@@ -7,7 +7,7 @@ package com.mux.player.offline
  * ([percentDownloaded], [bytesDownloaded], [totalBytes]) reflect the download **at the moment the
  * snapshot was created** and are *never* updated afterward. To observe changes over time, register a
  * [Listener] with [MuxOfflineDownloads.addListener] (each callback delivers a fresh snapshot) or
- * re-query [MuxOfflineDownloads.download]/[MuxOfflineDownloads.downloads].
+ * re-query [MuxOfflineDownloads.getDownload]/[MuxOfflineDownloads.allDownloads].
  *
  * You don't create these yourself; the SDK hands them to you from [MuxOfflineDownloads].
  */

--- a/library/src/main/java/com/mux/player/offline/MuxDownload.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownload.kt
@@ -1,0 +1,123 @@
+package com.mux.player.offline
+
+/**
+ * A **snapshot** of a single Mux offline download, keyed by its playback ID.
+ *
+ * Instances are immutable point-in-time readings. The [state] and progress values
+ * ([percentDownloaded], [bytesDownloaded], [totalBytes]) reflect the download **at the moment the
+ * snapshot was created** and are *never* updated afterward. To observe changes over time, register a
+ * [Listener] with [MuxOfflineDownloads.addListener] (each callback delivers a fresh snapshot) or
+ * re-query [MuxOfflineDownloads.download]/[MuxOfflineDownloads.downloads].
+ *
+ * You don't create these yourself; the SDK hands them to you from [MuxOfflineDownloads].
+ */
+class MuxDownload internal constructor(
+  /** The Mux playback ID this download was started for. Stable for the life of the download. */
+  val playbackId: String,
+  /** The download's state at the time this snapshot was taken. See [State]. */
+  val state: State,
+  /**
+   * How much of the download has completed, in the range `0.0..100.0`, or `-1f`
+   * ([androidx.media3.common.C.PERCENTAGE_UNSET]) if not yet known. Snapshot only — not live.
+   */
+  val percentDownloaded: Float,
+  /** Bytes downloaded to disk so far at the time of this snapshot. */
+  val bytesDownloaded: Long,
+  /**
+   * Total size of the download in bytes, or `-1` ([androidx.media3.common.C.LENGTH_UNSET]) if not
+   * yet known (the content length isn't resolved until the download begins).
+   */
+  val totalBytes: Long,
+) {
+
+  /**
+   * The lifecycle state of a [MuxDownload].
+   *
+   * Beyond the states Media3's `DownloadManager` reports, this adds [STARTING] to cover the work Mux
+   * does *before* a download is handed to the `DownloadManager`: fetching the HLS manifests and, for
+   * DRM content, acquiring the offline license. During that window there is no `DownloadManager`
+   * entry yet, so [STARTING] is the only signal that a download is in flight.
+   */
+  enum class State {
+    /**
+     * Mux is preparing the download — fetching manifests and (for DRM) acquiring the offline
+     * license — but it has **not** been queued on the `DownloadManager` yet. This precedes [QUEUED].
+     * If preparation fails, the next snapshot is [FAILED]; there is no `DownloadManager` entry for a
+     * download that never left this state.
+     */
+    STARTING,
+
+    /** Queued on the `DownloadManager`, waiting for a slot (or for requirements to be met). */
+    QUEUED,
+
+    /** Actively downloading media to disk. */
+    DOWNLOADING,
+
+    /** Fully downloaded and available for offline playback. */
+    COMPLETED,
+
+    /** The download failed. When reported via [Listener.onDownloadChanged], the cause is provided. */
+    FAILED,
+
+    /** The download is being removed and its media deleted. */
+    REMOVING,
+
+    /** Stopped (e.g. paused) and will not progress until resumed. */
+    STOPPED,
+  }
+
+  /**
+   * Observes offline-download progress and lifecycle changes.
+   *
+   * Callbacks are driven by Media3's `DownloadManager.Listener` (plus Mux's [State.STARTING] phase),
+   * translated to deliver [MuxDownload] snapshots instead of raw Media3 types. All callbacks are
+   * delivered on the `DownloadManager`'s application looper (the main thread in normal use).
+   *
+   * Register with [MuxOfflineDownloads.addListener] and unregister with
+   * [MuxOfflineDownloads.removeListener].
+   */
+  interface Listener {
+    /**
+     * Called whenever a download's [state][State] or progress changes, including the initial
+     * [State.STARTING] snapshot emitted by [MuxOfflineDownloads.startDownload].
+     *
+     * @param download a fresh snapshot of the download at this transition.
+     * @param error the cause when [download].state is [State.FAILED], otherwise `null`.
+     */
+    fun onDownloadChanged(download: MuxDownload, error: Throwable?)
+
+    /**
+     * Called when a download has been removed. [download] is the last snapshot before removal.
+     */
+    fun onDownloadRemoved(download: MuxDownload) {}
+
+    /**
+     * Called when there is a change in whether one or more downloads are stalled *solely* because
+     * the `DownloadManager`'s requirements (e.g. network connectivity) are not met.
+     */
+    fun onWaitingForRequirementsChanged(waitingForRequirements: Boolean) {}
+  }
+
+  override fun toString(): String =
+    "MuxDownload(playbackId='$playbackId', state=$state, percentDownloaded=$percentDownloaded, " +
+      "bytesDownloaded=$bytesDownloaded, totalBytes=$totalBytes)"
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is MuxDownload) return false
+    return playbackId == other.playbackId
+      && state == other.state
+      && percentDownloaded == other.percentDownloaded
+      && bytesDownloaded == other.bytesDownloaded
+      && totalBytes == other.totalBytes
+  }
+
+  override fun hashCode(): Int {
+    var result = playbackId.hashCode()
+    result = 31 * result + state.hashCode()
+    result = 31 * result + percentDownloaded.hashCode()
+    result = 31 * result + bytesDownloaded.hashCode()
+    result = 31 * result + totalBytes.hashCode()
+    return result
+  }
+}

--- a/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
@@ -13,6 +13,7 @@ import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadIndex
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadService
+import androidx.media3.exoplayer.scheduler.Requirements
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import com.mux.player.internal.createLogcatLogger
@@ -39,6 +40,14 @@ import java.util.concurrent.CopyOnWriteArraySet
  */
 @OptIn(UnstableApi::class)
 object MuxDownloadManager {
+
+  /**
+   * The requirements downloads must satisfy to make progress, applied to the `DownloadManager` on
+   * first use. The default requires only a network connection, including metered ones — pass
+   * [Requirements] including [Requirements.NETWORK_UNMETERED] to [setRequirements] to restrict
+   * downloads to unmetered (e.g. Wi-Fi) networks.
+   */
+  val DEFAULT_REQUIREMENTS: Requirements = Requirements(Requirements.NETWORK)
 
   /**
    * Observes offline-download progress and lifecycle changes.
@@ -132,8 +141,7 @@ object MuxDownloadManager {
           )
         },
         onError = { e ->
-          // Preparation failed before the DownloadManager ever saw this download, so the manager's
-          // listener won't report it — surface the failure ourselves.
+          // Preparation failed before the DownloadManager ever saw this download, so report here
           dispatchListenerCallOnMain(store) { it.onDownloadChanged(failedSnapshot(playbackId), e) }
         },
       )
@@ -173,6 +181,20 @@ object MuxDownloadManager {
   }
 
   /**
+   * Sets the [Requirements] that must be met for downloads to make progress, replacing the current
+   * ones (initially [DEFAULT_REQUIREMENTS], i.e. network only). Downloads that don't meet the new
+   * requirements move to a waiting state until they do.
+   *
+   * For example, to restrict downloads to unmetered (e.g. Wi-Fi) networks:
+   * `setRequirements(context, Requirements(Requirements.NETWORK_UNMETERED))`.
+   */
+  fun setRequirements(context: Context, requirements: Requirements) {
+    DownloadService.sendSetRequirements(
+      context.applicationContext, MuxDownloadService::class.java, requirements, /* foreground = */ false,
+    )
+  }
+
+  /**
    * Registers [listener] to observe download progress and lifecycle. Callbacks are delivered on the
    * `DownloadManager`'s application looper (the main thread in normal use). Non-blocking. Remove it
    * with [removeListener].
@@ -188,7 +210,7 @@ object MuxDownloadManager {
     listeners.remove(listener)
   }
 
-  /** All downloads known to the index, in any state. Runs the SQLite read off the main thread. */
+  /** All downloads known to the index, in any state */
   suspend fun allDownloads(context: Context): List<MuxDownload> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return withContext(store.ioExecutor.asCoroutineDispatcher()) {
@@ -196,7 +218,7 @@ object MuxDownloadManager {
     }
   }
 
-  /** Only fully-downloaded assets ([MuxDownload.State.COMPLETED]). Runs off the main thread. */
+  /** Only fully-downloaded assets ([MuxDownload.State.COMPLETED]). */
   suspend fun completedDownloads(context: Context): List<MuxDownload> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return withContext(store.ioExecutor.asCoroutineDispatcher()) {
@@ -208,7 +230,7 @@ object MuxDownloadManager {
    * The download for [playbackId], or `null` if there is none. Runs off the main thread.
    *
    * You don't need to call this in order to play a downloaded asset.
-   * Just use [com.mux.player.media.MediaItems.forMuxDownload]
+   * Just use [com.mux.player.media.MediaItems.forMuxDownload] and add the returned MediaItem.
    */
   suspend fun getDownload(context: Context, playbackId: String): MuxDownload? {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)

--- a/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
@@ -33,14 +33,46 @@ import java.util.concurrent.CopyOnWriteArraySet
  * Everything is backed by the process-wide [MuxPlayerDownloadStore] — the same `DownloadManager` and
  * `DownloadIndex` the service acts on — so this facade and the service always agree.
  *
- * This is a plain `object`. Kotlin callers use `MuxOfflineDownloads.startDownload(...)`; Java callers
- * use `MuxOfflineDownloads.INSTANCE.startDownload(...)` (kept as instance methods so they're mockable
+ * This is a plain `object`. Kotlin callers use `MuxDownloadManager.startDownload(...)`; Java callers
+ * use `MuxDownloadManager.INSTANCE.startDownload(...)` (kept as instance methods so they're mockable
  * without static mocking). Java callers that want the enumeration reads use the `*Future` variants.
  */
 @OptIn(UnstableApi::class)
-object MuxOfflineDownloads {
+object MuxDownloadManager {
 
-  private val listeners = CopyOnWriteArraySet<MuxDownload.Listener>()
+  /**
+   * Observes offline-download progress and lifecycle changes.
+   *
+   * Callbacks are driven by Media3's `DownloadManager.Listener` (plus Mux's
+   * [MuxDownload.State.STARTING] phase), translated to deliver [MuxDownload] snapshots instead of
+   * raw Media3 types. All callbacks are delivered on the `DownloadManager`'s application looper (the
+   * main thread in normal use).
+   *
+   * Register with [addListener] and unregister with [removeListener].
+   */
+  interface Listener {
+    /**
+     * Called whenever a download's [state][MuxDownload.State] or progress changes, including the
+     * initial [MuxDownload.State.STARTING] snapshot emitted by [startDownload].
+     *
+     * @param download a fresh snapshot of the download at this transition.
+     * @param error the cause when [download].state is [MuxDownload.State.FAILED], otherwise `null`.
+     */
+    fun onDownloadChanged(download: MuxDownload, error: Throwable?)
+
+    /**
+     * Called when a download has been removed. [download] is the last snapshot before removal.
+     */
+    fun onDownloadRemoved(download: MuxDownload) {}
+
+    /**
+     * Called when there is a change in whether one or more downloads are stalled *solely* because
+     * the `DownloadManager`'s requirements (e.g. network connectivity) are not met.
+     */
+    fun onWaitingForRequirementsChanged(waitingForRequirements: Boolean) {}
+  }
+
+  private val listeners = CopyOnWriteArraySet<Listener>()
 
   // Guards installation of our single DownloadManager.Listener onto the store's manager.
   private val installLock = Any()
@@ -145,18 +177,16 @@ object MuxOfflineDownloads {
    * `DownloadManager`'s application looper (the main thread in normal use). Non-blocking. Remove it
    * with [removeListener].
    */
-  fun addListener(context: Context, listener: MuxDownload.Listener) {
+  fun addListener(context: Context, listener: Listener) {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     ensureManagerListenerInstalled(store)
     listeners.add(listener)
   }
 
   /** Unregisters a [listener] previously added with [addListener]. */
-  fun removeListener(listener: MuxDownload.Listener) {
+  fun removeListener(listener: Listener) {
     listeners.remove(listener)
   }
-
-  // region enumeration (Kotlin)
 
   /** All downloads known to the index, in any state. Runs the SQLite read off the main thread. */
   suspend fun allDownloads(context: Context): List<MuxDownload> {
@@ -208,7 +238,7 @@ object MuxOfflineDownloads {
     }
   }
 
-  /** Translates the shared `DownloadManager.Listener` into [MuxDownload.Listener] callbacks. */
+  /** Translates the shared `DownloadManager.Listener` into [Listener] callbacks. */
   private object ManagerListener : DownloadManager.Listener {
     override fun onDownloadChanged(
       downloadManager: DownloadManager,
@@ -238,7 +268,7 @@ object MuxOfflineDownloads {
    */
   private fun dispatch(
     store: MuxPlayerDownloadStore,
-    block: (MuxDownload.Listener) -> Unit,
+    block: (Listener) -> Unit,
   ) {
     Handler(store.downloadManager.applicationLooper).post {
       listeners.forEach(block)

--- a/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
@@ -31,17 +31,12 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 
 /**
- * The caller-facing entry point for Mux offline downloads.
+ * The caller-facing entry point for Mux offline downloads. [startDownload] prepares an asset
+ * (fetching manifests, and for DRM acquiring an offline license) and enqueues it on
+ * [MuxDownloadService]; [addListener] observes progress and lifecycle
  *
- * Most apps need nothing else. [startDownload] prepares an asset (fetching manifests, and for DRM
- * acquiring an offline license) and enqueues it on [MuxDownloadService]; [addListener] observes
- * progress and lifecycle as [MuxDownload] snapshots; the enumeration methods list what's on disk.
- * Everything is backed by the process-wide [MuxPlayerDownloadStore] — the same `DownloadManager` and
- * `DownloadIndex` the service acts on — so this facade and the service always agree.
- *
- * This is a plain `object`. Kotlin callers use `MuxDownloadManager.startDownload(...)`; Java callers
- * use `MuxDownloadManager.INSTANCE.startDownload(...)` (kept as instance methods so they're mockable
- * without static mocking). Java callers that want the enumeration reads use the `*Future` variants.
+ * If you'd rather manage your own download lifecycle and datastore, you can skip using this class
+ * and use [MuxHlsDownloadCallback] with your own [DownloadHelper], [DownloadService], etc
  */
 @OptIn(UnstableApi::class)
 object MuxDownloadManager {
@@ -59,16 +54,14 @@ object MuxDownloadManager {
   /**
    * Observes offline-download progress and lifecycle changes.
    *
-   * Callbacks are driven by Media3's `DownloadManager.Listener` (plus Mux's
-   * [MuxDownload.State.STARTING] phase), translated to deliver [MuxDownload] snapshots instead of
-   * raw Media3 types. All callbacks are delivered on the `DownloadManager`'s application looper (the
-   * main thread in normal use).
+   * All callbacks are delivered on the `DownloadManager`'s application looper, which should be the
+   * main thread.
    *
    * Register with [addListener] and unregister with [removeListener].
    */
   interface Listener {
     /**
-     * Called whenever a download's [state][MuxDownload.State] or progress changes, including the
+     * Called whenever a download's [MuxDownload.State] or progress changes, including the
      * initial [MuxDownload.State.STARTING] snapshot emitted by [startDownload].
      *
      * @param download a fresh snapshot of the download at this transition.

--- a/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
@@ -102,7 +102,7 @@ object MuxDownloadManager {
 
     // Announce STARTING before the (async) manifest/license work — there is no DownloadManager
     // entry for this download yet, so this snapshot is the only signal it's in flight.
-    dispatch(store) { it.onDownloadChanged(startingSnapshot(playbackId), null) }
+    dispatchListenerCallOnMain(store) { it.onDownloadChanged(startingSnapshot(playbackId), null) }
 
     val logger = createLogcatLogger()
     val drmProvider = MuxDrmSessionManagerProvider(
@@ -134,7 +134,7 @@ object MuxDownloadManager {
         onError = { e ->
           // Preparation failed before the DownloadManager ever saw this download, so the manager's
           // listener won't report it — surface the failure ourselves.
-          dispatch(store) { it.onDownloadChanged(failedSnapshot(playbackId), e) }
+          dispatchListenerCallOnMain(store) { it.onDownloadChanged(failedSnapshot(playbackId), e) }
         },
       )
     )
@@ -215,19 +215,19 @@ object MuxDownloadManager {
   /** Java twin of [allDownloads]. */
   fun allDownloadsFuture(context: Context): ListenableFuture<List<MuxDownload>> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
-    return submit(store) { store.downloadIndex.readAll() }
+    return submitToIoExecutor(store) { store.downloadIndex.readAll() }
   }
 
   /** Java twin of [getCompletedDownloads]. */
   fun completedDownloadsFuture(context: Context): ListenableFuture<List<MuxDownload>> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
-    return submit(store) { store.downloadIndex.readAll(Download.STATE_COMPLETED) }
+    return submitToIoExecutor(store) { store.downloadIndex.readAll(Download.STATE_COMPLETED) }
   }
 
   /** Java twin of [getDownload]. */
   fun getDownloadFuture(context: Context, playbackId: String): ListenableFuture<MuxDownload?> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
-    return submit(store) { store.downloadIndex.getDownload(playbackId)?.toMuxDownload() }
+    return submitToIoExecutor(store) { store.downloadIndex.getDownload(playbackId)?.toMuxDownload() }
   }
 
   private fun ensureManagerListenerInstalled(store: MuxPlayerDownloadStore) {
@@ -266,7 +266,7 @@ object MuxDownloadManager {
    * Posts [block] to each listener on the `DownloadManager`'s application looper, so our synthetic
    * STARTING/FAILED snapshots are delivered on the same thread as the manager's own callbacks.
    */
-  private fun dispatch(
+  private fun dispatchListenerCallOnMain(
     store: MuxPlayerDownloadStore,
     block: (Listener) -> Unit,
   ) {
@@ -275,7 +275,7 @@ object MuxDownloadManager {
     }
   }
 
-  private fun <T> submit(
+  private fun <T> submitToIoExecutor(
     store: MuxPlayerDownloadStore,
     block: () -> T,
   ): ListenableFuture<T> {

--- a/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
@@ -197,14 +197,19 @@ object MuxDownloadManager {
   }
 
   /** Only fully-downloaded assets ([MuxDownload.State.COMPLETED]). Runs off the main thread. */
-  suspend fun getCompletedDownloads(context: Context): List<MuxDownload> {
+  suspend fun completedDownloads(context: Context): List<MuxDownload> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return withContext(store.ioExecutor.asCoroutineDispatcher()) {
       store.downloadIndex.readAll(Download.STATE_COMPLETED)
     }
   }
 
-  /** The download for [playbackId], or `null` if there is none. Runs off the main thread. */
+  /**
+   * The download for [playbackId], or `null` if there is none. Runs off the main thread.
+   *
+   * You don't need to call this in order to play a downloaded asset.
+   * Just use [com.mux.player.media.MediaItems.forMuxDownload]
+   */
   suspend fun getDownload(context: Context, playbackId: String): MuxDownload? {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return withContext(store.ioExecutor.asCoroutineDispatcher()) {
@@ -218,7 +223,7 @@ object MuxDownloadManager {
     return submitToIoExecutor(store) { store.downloadIndex.readAll() }
   }
 
-  /** Java twin of [getCompletedDownloads]. */
+  /** Java twin of [completedDownloads]. */
   fun completedDownloadsFuture(context: Context): ListenableFuture<List<MuxDownload>> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return submitToIoExecutor(store) { store.downloadIndex.readAll(Download.STATE_COMPLETED) }

--- a/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
@@ -4,16 +4,20 @@ import android.content.Context
 import android.media.MediaDrm
 import android.os.Build
 import android.os.Handler
+import android.util.Log
+import androidx.annotation.MainThread
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadHelper
 import androidx.media3.exoplayer.offline.DownloadIndex
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.media3.exoplayer.scheduler.Requirements
+import com.google.common.collect.ConcurrentHashMultiset
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import com.mux.player.internal.createLogcatLogger
@@ -23,6 +27,7 @@ import com.mux.player.internal.getPlaybackId
 import com.mux.player.media.MuxDrmSessionManagerProvider
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 
 /**
@@ -48,6 +53,8 @@ object MuxDownloadManager {
    * downloads to unmetered (e.g. Wi-Fi) networks.
    */
   val DEFAULT_REQUIREMENTS: Requirements = Requirements(Requirements.NETWORK)
+
+  private const val TAG = "MuxDownloadManager"
 
   /**
    * Observes offline-download progress and lifecycle changes.
@@ -87,27 +94,33 @@ object MuxDownloadManager {
   private val installLock = Any()
   private var installed = false
 
+  private val playbackIdsStarting = ConcurrentHashMap<String, DownloadHelper>()
+
   /**
    * Prepares [mediaItem] for offline playback and enqueues the download.
    *
    * The download id is the item's Mux playback ID. Preparation — fetching the HLS manifests and,
    * for DRM content, acquiring the offline Widevine license — runs asynchronously; during it,
-   * listeners see a [MuxDownload.State.STARTING] snapshot. Once prepared, the resulting
-   * `DownloadRequest` is handed to [MuxDownloadService] and the `DownloadManager` takes over
-   * ([MuxDownload.State.QUEUED] onward). If preparation fails before the download is queued, a
-   * [MuxDownload.State.FAILED] snapshot is delivered to listeners with the cause.
+   * listeners see a [MuxDownload.State.STARTING] snapshot. Once prepared, the download states are
+   * the similar to media3.
    *
    * @param context any context; the application context is used.
    * @param mediaItem a Mux [MediaItem] (built via `MediaItems.fromMuxPlaybackId`). Must carry a
-   *   playback ID; DRM items must also carry a DRM token.
+   *   playback ID; DRM items must also carry playback and DRM tokens.
    * @throws IllegalArgumentException if [mediaItem] is not a Mux media item (no playback ID).
    */
+  @MainThread
   fun startDownload(context: Context, mediaItem: MediaItem) {
     val appContext = context.applicationContext
     val playbackId = requireNotNull(mediaItem.getPlaybackId()) {
       "mediaItem is not a Mux MediaItem (no playback ID). Build it with MediaItems.fromMuxPlaybackId."
     }
     val store = MuxPlayerDownloadStore.get(appContext)
+
+    if (this.playbackIdsStarting[playbackId] != null) {
+      Log.w(TAG, "Trying to start already-started download for playback ID $playbackId")
+      return
+    }
 
     // Announce STARTING before the (async) manifest/license work — there is no DownloadManager
     // entry for this download yet, so this snapshot is the only signal it's in flight.
@@ -124,6 +137,8 @@ object MuxDownloadManager {
       drmSessionManagerProvider = drmProvider,
     )
     val helper = createMuxHlsDownloadHelper(appContext, mediaSource)
+
+    this.playbackIdsStarting[playbackId] = helper
     helper.prepare(
       MuxHlsDownloadCallback(
         mediaSource = mediaSource,
@@ -133,16 +148,24 @@ object MuxDownloadManager {
         licenseEndpointHost = mediaItem.getLicenseUrlHost(),
         ioExecutor = store.ioExecutor,
         onReady = { request ->
-          DownloadService.sendAddDownload(
-            appContext,
-            MuxDownloadService::class.java,
-            request,
-            /* foreground = */ false,
-          )
+          // Start the prepared Download unless it was removed in the meantime
+          if (playbackIdsStarting[playbackId] != null) {
+            DownloadService.sendAddDownload(
+              appContext,
+              MuxDownloadService::class.java,
+              request,
+              /* foreground = */ false,
+            )
+            playbackIdsStarting.remove(playbackId)
+          } else {
+            // If removed we might need to try to drop the license from the cdm cache
+            request.keySetId?.let { dropOfflineLicense(it) }
+          }
         },
         onError = { e ->
           // Preparation failed before the DownloadManager ever saw this download, so report here
           dispatchListenerCallOnMain(store) { it.onDownloadChanged(failedSnapshot(playbackId), e) }
+          playbackIdsStarting.remove(playbackId)
         },
       )
     )
@@ -164,6 +187,9 @@ object MuxDownloadManager {
       )
       keySetId?.let { dropOfflineLicense(it) }
     }
+
+    this.playbackIdsStarting.remove(playbackId)
+
   }
 
   /** Pauses all downloads. They can be resumed with [resumeAll]. */

--- a/library/src/main/java/com/mux/player/offline/MuxOfflineDownloads.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxOfflineDownloads.kt
@@ -12,7 +12,6 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadIndex
 import androidx.media3.exoplayer.offline.DownloadManager
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
@@ -113,7 +112,7 @@ object MuxOfflineDownloads {
    * Removes a download: deletes its media via the `DownloadManager` and drops the local offline
    * license, if any. Safe to call for an unknown [playbackId] (no-op). Runs off the caller thread.
    */
-  fun remove(context: Context, playbackId: String) {
+  fun removeDownload(context: Context, playbackId: String) {
     val appContext = context.applicationContext
     val store = MuxPlayerDownloadStore.get(appContext)
     store.ioExecutor.execute {
@@ -160,7 +159,7 @@ object MuxOfflineDownloads {
   // region enumeration (Kotlin)
 
   /** All downloads known to the index, in any state. Runs the SQLite read off the main thread. */
-  suspend fun downloads(context: Context): List<MuxDownload> {
+  suspend fun allDownloads(context: Context): List<MuxDownload> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return withContext(store.ioExecutor.asCoroutineDispatcher()) {
       store.downloadIndex.readAll()
@@ -168,7 +167,7 @@ object MuxOfflineDownloads {
   }
 
   /** Only fully-downloaded assets ([MuxDownload.State.COMPLETED]). Runs off the main thread. */
-  suspend fun downloaded(context: Context): List<MuxDownload> {
+  suspend fun getCompletedDownloads(context: Context): List<MuxDownload> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return withContext(store.ioExecutor.asCoroutineDispatcher()) {
       store.downloadIndex.readAll(Download.STATE_COMPLETED)
@@ -176,36 +175,30 @@ object MuxOfflineDownloads {
   }
 
   /** The download for [playbackId], or `null` if there is none. Runs off the main thread. */
-  suspend fun download(context: Context, playbackId: String): MuxDownload? {
+  suspend fun getDownload(context: Context, playbackId: String): MuxDownload? {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return withContext(store.ioExecutor.asCoroutineDispatcher()) {
       store.downloadIndex.getDownload(playbackId)?.toMuxDownload()
     }
   }
 
-  // endregion
-
-  // region enumeration (Java) — same reads, resolved on the store's ioExecutor
-
-  /** Java twin of [downloads]. */
-  fun downloadsFuture(context: Context): ListenableFuture<List<MuxDownload>> {
+  /** Java twin of [allDownloads]. */
+  fun allDownloadsFuture(context: Context): ListenableFuture<List<MuxDownload>> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return submit(store) { store.downloadIndex.readAll() }
   }
 
-  /** Java twin of [downloaded]. */
-  fun downloadedFuture(context: Context): ListenableFuture<List<MuxDownload>> {
+  /** Java twin of [getCompletedDownloads]. */
+  fun completedDownloadsFuture(context: Context): ListenableFuture<List<MuxDownload>> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return submit(store) { store.downloadIndex.readAll(Download.STATE_COMPLETED) }
   }
 
-  /** Java twin of [download]. */
-  fun downloadFuture(context: Context, playbackId: String): ListenableFuture<MuxDownload?> {
+  /** Java twin of [getDownload]. */
+  fun getDownloadFuture(context: Context, playbackId: String): ListenableFuture<MuxDownload?> {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
     return submit(store) { store.downloadIndex.getDownload(playbackId)?.toMuxDownload() }
   }
-
-  // endregion
 
   private fun ensureManagerListenerInstalled(store: MuxPlayerDownloadStore) {
     synchronized(installLock) {

--- a/library/src/main/java/com/mux/player/offline/MuxOfflineDownloads.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxOfflineDownloads.kt
@@ -1,0 +1,336 @@
+package com.mux.player.offline
+
+import android.content.Context
+import android.media.MediaDrm
+import android.os.Build
+import android.os.Handler
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadIndex
+import androidx.media3.exoplayer.offline.DownloadManager
+import androidx.media3.exoplayer.offline.DownloadRequest
+import androidx.media3.exoplayer.offline.DownloadService
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import com.mux.player.internal.createLogcatLogger
+import com.mux.player.internal.getDrmToken
+import com.mux.player.internal.getLicenseUrlHost
+import com.mux.player.internal.getPlaybackId
+import com.mux.player.media.MuxDrmSessionManagerProvider
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.util.concurrent.CopyOnWriteArraySet
+
+/**
+ * The caller-facing entry point for Mux offline downloads.
+ *
+ * Most apps need nothing else. [startDownload] prepares an asset (fetching manifests, and for DRM
+ * acquiring an offline license) and enqueues it on [MuxDownloadService]; [addListener] observes
+ * progress and lifecycle as [MuxDownload] snapshots; the enumeration methods list what's on disk.
+ * Everything is backed by the process-wide [MuxPlayerDownloadStore] — the same `DownloadManager` and
+ * `DownloadIndex` the service acts on — so this facade and the service always agree.
+ *
+ * This is a plain `object`. Kotlin callers use `MuxOfflineDownloads.startDownload(...)`; Java callers
+ * use `MuxOfflineDownloads.INSTANCE.startDownload(...)` (kept as instance methods so they're mockable
+ * without static mocking). Java callers that want the enumeration reads use the `*Future` variants.
+ */
+@OptIn(UnstableApi::class)
+object MuxOfflineDownloads {
+
+  private val listeners = CopyOnWriteArraySet<MuxDownload.Listener>()
+
+  // Guards installation of our single DownloadManager.Listener onto the store's manager.
+  private val installLock = Any()
+  private var installed = false
+
+  /**
+   * Prepares [mediaItem] for offline playback and enqueues the download.
+   *
+   * The download id is the item's Mux playback ID. Preparation — fetching the HLS manifests and,
+   * for DRM content, acquiring the offline Widevine license — runs asynchronously; during it,
+   * listeners see a [MuxDownload.State.STARTING] snapshot. Once prepared, the resulting
+   * `DownloadRequest` is handed to [MuxDownloadService] and the `DownloadManager` takes over
+   * ([MuxDownload.State.QUEUED] onward). If preparation fails before the download is queued, a
+   * [MuxDownload.State.FAILED] snapshot is delivered to listeners with the cause.
+   *
+   * @param context any context; the application context is used.
+   * @param mediaItem a Mux [MediaItem] (built via `MediaItems.fromMuxPlaybackId`). Must carry a
+   *   playback ID; DRM items must also carry a DRM token.
+   * @throws IllegalArgumentException if [mediaItem] is not a Mux media item (no playback ID).
+   */
+  fun startDownload(context: Context, mediaItem: MediaItem) {
+    val appContext = context.applicationContext
+    val playbackId = requireNotNull(mediaItem.getPlaybackId()) {
+      "mediaItem is not a Mux MediaItem (no playback ID). Build it with MediaItems.fromMuxPlaybackId."
+    }
+    val store = MuxPlayerDownloadStore.get(appContext)
+
+    // Announce STARTING before the (async) manifest/license work — there is no DownloadManager
+    // entry for this download yet, so this snapshot is the only signal it's in flight.
+    dispatch(store) { it.onDownloadChanged(startingSnapshot(playbackId), null) }
+
+    val logger = createLogcatLogger()
+    val drmProvider = MuxDrmSessionManagerProvider(
+      drmHttpDataSourceFactory = DefaultHttpDataSource.Factory(),
+      logger = logger,
+    )
+    val mediaSource = MuxOfflineCmafHlsMediaSource.create(
+      dataSourceFactory = DefaultHttpDataSource.Factory(),
+      mediaItem = mediaItem,
+      drmSessionManagerProvider = drmProvider,
+    )
+    val helper = createMuxHlsDownloadHelper(appContext, mediaSource)
+    helper.prepare(
+      MuxHlsDownloadCallback(
+        mediaSource = mediaSource,
+        drmProvider = drmProvider,
+        playbackId = playbackId,
+        drmToken = mediaItem.getDrmToken(),
+        licenseEndpointHost = mediaItem.getLicenseUrlHost(),
+        ioExecutor = store.ioExecutor,
+        onReady = { request ->
+          DownloadService.sendAddDownload(
+            appContext,
+            MuxDownloadService::class.java,
+            request,
+            /* foreground = */ false,
+          )
+        },
+        onError = { e ->
+          // Preparation failed before the DownloadManager ever saw this download, so the manager's
+          // listener won't report it — surface the failure ourselves.
+          dispatch(store) { it.onDownloadChanged(failedSnapshot(playbackId), e) }
+        },
+      )
+    )
+  }
+
+  /**
+   * Removes a download: deletes its media via the `DownloadManager` and drops the local offline
+   * license, if any. Safe to call for an unknown [playbackId] (no-op). Runs off the caller thread.
+   */
+  fun remove(context: Context, playbackId: String) {
+    val appContext = context.applicationContext
+    val store = MuxPlayerDownloadStore.get(appContext)
+    store.ioExecutor.execute {
+      // Capture the keySetId before the index row is gone; removal is what actually deletes media.
+      val keySetId = runCatching { store.downloadIndex.getDownload(playbackId)?.request?.keySetId }
+        .getOrNull()
+      DownloadService.sendRemoveDownload(
+        appContext, MuxDownloadService::class.java, playbackId, /* foreground = */ false,
+      )
+      keySetId?.let { dropOfflineLicense(it) }
+    }
+  }
+
+  /** Pauses all downloads. They can be resumed with [resumeAll]. */
+  fun pauseAll(context: Context) {
+    DownloadService.sendPauseDownloads(
+      context.applicationContext, MuxDownloadService::class.java, /* foreground = */ false,
+    )
+  }
+
+  /** Resumes all downloads paused by [pauseAll]. */
+  fun resumeAll(context: Context) {
+    DownloadService.sendResumeDownloads(
+      context.applicationContext, MuxDownloadService::class.java, /* foreground = */ false,
+    )
+  }
+
+  /**
+   * Registers [listener] to observe download progress and lifecycle. Callbacks are delivered on the
+   * `DownloadManager`'s application looper (the main thread in normal use). Non-blocking. Remove it
+   * with [removeListener].
+   */
+  fun addListener(context: Context, listener: MuxDownload.Listener) {
+    val store = MuxPlayerDownloadStore.get(context.applicationContext)
+    ensureManagerListenerInstalled(store)
+    listeners.add(listener)
+  }
+
+  /** Unregisters a [listener] previously added with [addListener]. */
+  fun removeListener(listener: MuxDownload.Listener) {
+    listeners.remove(listener)
+  }
+
+  // region enumeration (Kotlin)
+
+  /** All downloads known to the index, in any state. Runs the SQLite read off the main thread. */
+  suspend fun downloads(context: Context): List<MuxDownload> {
+    val store = MuxPlayerDownloadStore.get(context.applicationContext)
+    return withContext(store.ioExecutor.asCoroutineDispatcher()) {
+      store.downloadIndex.readAll()
+    }
+  }
+
+  /** Only fully-downloaded assets ([MuxDownload.State.COMPLETED]). Runs off the main thread. */
+  suspend fun downloaded(context: Context): List<MuxDownload> {
+    val store = MuxPlayerDownloadStore.get(context.applicationContext)
+    return withContext(store.ioExecutor.asCoroutineDispatcher()) {
+      store.downloadIndex.readAll(Download.STATE_COMPLETED)
+    }
+  }
+
+  /** The download for [playbackId], or `null` if there is none. Runs off the main thread. */
+  suspend fun download(context: Context, playbackId: String): MuxDownload? {
+    val store = MuxPlayerDownloadStore.get(context.applicationContext)
+    return withContext(store.ioExecutor.asCoroutineDispatcher()) {
+      store.downloadIndex.getDownload(playbackId)?.toMuxDownload()
+    }
+  }
+
+  // endregion
+
+  // region enumeration (Java) — same reads, resolved on the store's ioExecutor
+
+  /** Java twin of [downloads]. */
+  fun downloadsFuture(context: Context): ListenableFuture<List<MuxDownload>> {
+    val store = MuxPlayerDownloadStore.get(context.applicationContext)
+    return submit(store) { store.downloadIndex.readAll() }
+  }
+
+  /** Java twin of [downloaded]. */
+  fun downloadedFuture(context: Context): ListenableFuture<List<MuxDownload>> {
+    val store = MuxPlayerDownloadStore.get(context.applicationContext)
+    return submit(store) { store.downloadIndex.readAll(Download.STATE_COMPLETED) }
+  }
+
+  /** Java twin of [download]. */
+  fun downloadFuture(context: Context, playbackId: String): ListenableFuture<MuxDownload?> {
+    val store = MuxPlayerDownloadStore.get(context.applicationContext)
+    return submit(store) { store.downloadIndex.getDownload(playbackId)?.toMuxDownload() }
+  }
+
+  // endregion
+
+  private fun ensureManagerListenerInstalled(store: MuxPlayerDownloadStore) {
+    synchronized(installLock) {
+      if (installed) return
+      store.downloadManager.addListener(ManagerListener)
+      installed = true
+    }
+  }
+
+  /** Translates the shared `DownloadManager.Listener` into [MuxDownload.Listener] callbacks. */
+  private object ManagerListener : DownloadManager.Listener {
+    override fun onDownloadChanged(
+      downloadManager: DownloadManager,
+      download: Download,
+      finalException: Exception?,
+    ) {
+      val snapshot = download.toMuxDownload()
+      listeners.forEach { it.onDownloadChanged(snapshot, finalException) }
+    }
+
+    override fun onDownloadRemoved(downloadManager: DownloadManager, download: Download) {
+      val snapshot = download.toMuxDownload()
+      listeners.forEach { it.onDownloadRemoved(snapshot) }
+    }
+
+    override fun onWaitingForRequirementsChanged(
+      downloadManager: DownloadManager,
+      waitingForRequirements: Boolean,
+    ) {
+      listeners.forEach { it.onWaitingForRequirementsChanged(waitingForRequirements) }
+    }
+  }
+
+  /**
+   * Posts [block] to each listener on the `DownloadManager`'s application looper, so our synthetic
+   * STARTING/FAILED snapshots are delivered on the same thread as the manager's own callbacks.
+   */
+  private fun dispatch(
+    store: MuxPlayerDownloadStore,
+    block: (MuxDownload.Listener) -> Unit,
+  ) {
+    Handler(store.downloadManager.applicationLooper).post {
+      listeners.forEach(block)
+    }
+  }
+
+  private fun <T> submit(
+    store: MuxPlayerDownloadStore,
+    block: () -> T,
+  ): ListenableFuture<T> {
+    val future = SettableFuture.create<T>()
+    store.ioExecutor.execute {
+      try {
+        future.set(block())
+      } catch (t: Throwable) {
+        future.setException(t)
+      }
+    }
+    return future
+  }
+
+  private fun DownloadIndex.readAll(@Download.State vararg states: Int): List<MuxDownload> =
+    getDownloads(*states).use { cursor ->
+      buildList {
+        while (cursor.moveToNext()) {
+          add(cursor.download.toMuxDownload())
+        }
+      }
+    }
+
+  private fun startingSnapshot(playbackId: String): MuxDownload =
+    MuxDownload(
+      playbackId = playbackId,
+      state = MuxDownload.State.STARTING,
+      percentDownloaded = C.PERCENTAGE_UNSET.toFloat(),
+      bytesDownloaded = 0L,
+      totalBytes = C.LENGTH_UNSET.toLong(),
+    )
+
+  private fun failedSnapshot(playbackId: String): MuxDownload =
+    MuxDownload(
+      playbackId = playbackId,
+      state = MuxDownload.State.FAILED,
+      percentDownloaded = C.PERCENTAGE_UNSET.toFloat(),
+      bytesDownloaded = 0L,
+      totalBytes = C.LENGTH_UNSET.toLong(),
+    )
+
+  private fun Download.toMuxDownload(): MuxDownload =
+    MuxDownload(
+      playbackId = request.id,
+      state = state.toMuxState(),
+      percentDownloaded = percentDownloaded,
+      bytesDownloaded = bytesDownloaded,
+      totalBytes = contentLength,
+    )
+
+  private fun Int.toMuxState(): MuxDownload.State = when (this) {
+    Download.STATE_QUEUED -> MuxDownload.State.QUEUED
+    Download.STATE_STOPPED -> MuxDownload.State.STOPPED
+    Download.STATE_DOWNLOADING -> MuxDownload.State.DOWNLOADING
+    Download.STATE_COMPLETED -> MuxDownload.State.COMPLETED
+    Download.STATE_FAILED -> MuxDownload.State.FAILED
+    Download.STATE_REMOVING -> MuxDownload.State.REMOVING
+    Download.STATE_RESTARTING -> MuxDownload.State.DOWNLOADING
+    else -> MuxDownload.State.QUEUED
+  }
+
+  /**
+   * Local-only purge of the offline license keyed by [keySetId]. No network and no DRM token — Mux
+   * enforces no offline-license quota, so there is no server-side release. Best-effort.
+   */
+  private fun dropOfflineLicense(keySetId: ByteArray) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return // no per-license purge API pre-29
+    val mediaDrm = try {
+      MediaDrm(C.WIDEVINE_UUID)
+    } catch (_: Exception) {
+      return
+    }
+    try {
+      mediaDrm.removeOfflineLicense(keySetId)
+    } catch (_: Exception) {
+      // best-effort; the DownloadRequest reference is already gone, so any residue is unreferenced
+    } finally {
+      mediaDrm.close()
+    }
+  }
+}

--- a/library/src/main/java/com/mux/player/offline/MuxPlayerDownloadStore.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxPlayerDownloadStore.kt
@@ -97,7 +97,11 @@ private class DownloadStoreImpl(
       /*cache=*/ downloadCache,
       /*upstreamFactory=*/ DefaultHttpDataSource.Factory(),
       /*executor=*/ ioExecutor,
-    )
+    ).apply {
+      // Media3's own default is network-only; establish Mux's default (network + charging). Callers
+      // override it with MuxDownloadManager.setRequirements.
+      setRequirements(MuxDownloadManager.DEFAULT_REQUIREMENTS)
+    }
   }
 
   // Derived from the DownloadManager so the store and the manager share a single, consistent index


### PR DESCRIPTION
Most of these are calling-through directly to framework objects, or objects that we're already testing. As such, there's really nothing extra to unit-test here.

To limit PR scope, I'll put the example app in alongside the offline-playback path in the next (and hopefully final) PR for this project

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public surface area around Media3 downloads and DRM offline license handling; behavior is mostly delegation but prep/removal paths touch security-sensitive offline license state.
> 
> **Overview**
> Adds the **caller-facing offline download API** for Mux Player: a `MuxDownload` snapshot type (with a `STARTING` state for manifest/DRM prep before Media3 sees the job) and **`MuxDownloadManager`** to start downloads from Mux `MediaItem`s, remove them (including best-effort offline Widevine license purge), pause/resume all, set `Requirements`, register listeners, and query downloads via coroutines or `ListenableFuture`.
> 
> `startDownload` runs async HLS prep through existing `MuxHlsDownloadCallback` / `MuxDownloadService` plumbing and dedupes in-flight starts by playback ID. **`MediaItems.forMuxDownload`** is added as a **TODO stub** for future disk-backed playback items. **`MuxPlayerDownloadStore`** now applies `MuxDownloadManager.DEFAULT_REQUIREMENTS` (network, including metered) when the `DownloadManager` is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a14acbd4b6001b6c0844386f188079a99bff7025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->