### PR TITLE
InternalUtils.executePost should actually set its HTTP Method

### DIFF
--- a/library/src/main/java/com/mux/player/internal/InternalUtils.kt
+++ b/library/src/main/java/com/mux/player/internal/InternalUtils.kt
@@ -15,7 +15,7 @@ import kotlin.jvm.Throws
 @OptIn(UnstableApi::class)
 internal fun executePost(
   uri: Uri,
-  headers: Map<String, List<String>>,
+  headers: Map<String, List<String>> = mapOf(),
   requestBody: ByteArray?,
   dataSourceFactory: DataSource.Factory,
   ): ByteArray {
@@ -23,6 +23,7 @@ internal fun executePost(
     .setUri(uri)
     .setHttpRequestHeaders(headers.mapValues { it.value.last() })
     .setHttpBody(requestBody)
+    .setHttpMethod(DataSpec.HTTP_METHOD_POST)
     .build()
 
   val dataSource = dataSourceFactory.createDataSource()

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -126,7 +126,9 @@ class MuxDrmCallback(
       .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
     val uri = Uri.parse(
       request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data)
-    )
+    val uri = Uri.parse(request.defaultUrl).buildUpon()
+      .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
+      .build()
     logger.d(TAG, "executeProvisionRequest: license URI is $uri")
 
     try {

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -124,7 +124,9 @@ class MuxDrmCallback(
 
     val uri = Uri.parse(request.defaultUrl).buildUpon()
       .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
-      .build()
+    val uri = Uri.parse(
+      request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data)
+    )
     logger.d(TAG, "executeProvisionRequest: license URI is $uri")
 
     try {

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -2,6 +2,7 @@ package com.mux.player.media
 
 import android.annotation.SuppressLint
 import android.media.MediaDrm
+import android.net.Uri
 import android.util.Base64
 import androidx.annotation.OptIn
 import androidx.media3.common.C
@@ -111,23 +112,28 @@ class MuxDrmCallback(
     const val TAG = "MuxDrmCallback"
   }
 
+  @SuppressLint("UseKtx") // Uri ktx is not in the project
   override fun executeProvisionRequest(
     uuid: UUID,
     request: ProvisionRequest
   ): MediaDrmCallback.Response {
-    val widevine = uuid == C.WIDEVINE_UUID;
+    val widevine = uuid == C.WIDEVINE_UUID
     if (!widevine) {
       throw IOException("Mux player does not support scheme: $uuid")
     }
 
-    val url = request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data)
-    logger.d(TAG, "executeProvisionRequest: license URI is $url")
+    val uri = Uri.parse(request.defaultUrl).buildUpon()
+      .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
+      .build()
+    logger.d(TAG, "executeProvisionRequest: license URI is $uri")
 
     try {
-      return DrmUtil.executePost(
-        drmHttpDataSourceFactory.createDataSource(),
-        url, null,
-        emptyMap()
+      return MediaDrmCallback.Response(
+        executePost(
+          uri = uri,
+          requestBody = null,
+          dataSourceFactory = drmHttpDataSourceFactory
+        )
       )
     } catch (e: InvalidResponseCodeException) {
       logger.e(TAG, "Provisioning/License Request failed!", e)

--- a/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
+++ b/library/src/main/java/com/mux/player/media/MuxDrmSessionManagerProvider.kt
@@ -122,13 +122,9 @@ class MuxDrmCallback(
       throw IOException("Mux player does not support scheme: $uuid")
     }
 
-    val uri = Uri.parse(request.defaultUrl).buildUpon()
-      .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
     val uri = Uri.parse(
       request.defaultUrl + "&signedRequest=" + Util.fromUtf8Bytes(request.data)
-    val uri = Uri.parse(request.defaultUrl).buildUpon()
-      .appendQueryParameter("signedRequest", Util.fromUtf8Bytes(request.data))
-      .build()
+    )
     logger.d(TAG, "executeProvisionRequest: license URI is $uri")
 
     try {


### PR DESCRIPTION
Also, build provisioning URLs idiomatically


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Widevine provisioning and license HTTP paths; the POST method fix is correctness-critical for DRM but the change is small and localized.
> 
> **Overview**
> **`executePost`** now sets **`DataSpec.HTTP_METHOD_POST`** on the built request (it previously omitted the method despite the name) and gives **`headers`** a default empty map so callers can omit them.
> 
> Widevine **provisioning** in **`MuxDrmCallback.executeProvisionRequest`** no longer uses Media3’s **`DrmUtil.executePost`** with a raw URL string; it builds the URL with **`Uri.parse`**, logs the **`Uri`**, and uses the shared **`executePost`** with the DRM **`DataSource.Factory`**—aligned with how key requests already work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17b5e9d8d5c60fd7ec7ece672134359f05e88c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->