### PR TITLE
NAT-485: Add playback path for offline downloads

### DIFF
--- a/library/src/main/java/com/mux/player/media/MediaItems.kt
+++ b/library/src/main/java/com/mux/player/media/MediaItems.kt
@@ -186,10 +186,23 @@ object MediaItems {
       )
   }
 
+  /**
+   * Creates a new [MediaItem] that will play the downloaded media represented by [download]
+   *
+   * @param download The Download to play. If the media isn't downloaded, playback will fail
+   */
   fun forMuxDownload(download: MuxDownload): MediaItem {
     return forMuxDownload(download.playbackId, /*todo: download.title eventually*/)
   }
 
+  /**
+   * Creates a new [MediaItem] that will play the downloaded media with the given playback ID
+   *
+   * If there's no asset downloaded with the given playback ID, playback will fail
+   *
+   * @param playbackId The playbckID of the media to play
+   * @param title The title that should be displayed for the MediaItem
+   */
   fun forMuxDownload(playbackId: String, title: String? = null): MediaItem {
     val uri = Uri.Builder()
       .scheme(URI_SCHEME_MUX_OFFLINE)

--- a/library/src/main/java/com/mux/player/media/MediaItems.kt
+++ b/library/src/main/java/com/mux/player/media/MediaItems.kt
@@ -24,6 +24,11 @@ object MediaItems {
   internal const val EXTRA_VIDEO_DATA = "com.mux.video.customerdata"
 
   /**
+   * Scheme used for playing offline Mux assets via the [MuxMediaSourceFactory] and [forMuxDownload]
+   */
+  const val URI_SCHEME_MUX_OFFLINE = "mux_offline"
+
+  /**
    * Creates a new [MediaItem] that points to a given Mux Playback ID.
    *
    * ## Controlling resolution

--- a/library/src/main/java/com/mux/player/media/MediaItems.kt
+++ b/library/src/main/java/com/mux/player/media/MediaItems.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaItem.RequestMetadata
+import androidx.media3.common.MediaMetadata
 import com.mux.player.internal.Constants
+import com.mux.player.offline.MuxDownload
 
 /**
  * Creates instances of [MediaItem] or [MediaItem.Builder] configured for easy use with MuxPlayer`.
@@ -184,10 +186,27 @@ object MediaItems {
       )
   }
 
-  fun forMuxDownload(playbackId: String): MediaItem {
-    // stubbed for now. Will create a MediaItem that `MuxDataSourceFactory` knows play from disk
-    //  (no need to do anything async just to get the MediaItem)
-    TODO("stub for documentation's sake")
+  fun forMuxDownload(download: MuxDownload): MediaItem {
+    return forMuxDownload(download.playbackId, /*todo: download.title eventually*/)
+  }
+
+  fun forMuxDownload(playbackId: String, title: String? = null): MediaItem {
+    val uri = Uri.Builder()
+      .scheme(URI_SCHEME_MUX_OFFLINE)
+      .path(playbackId)
+      .build()
+    val builder = MediaItem.Builder()
+      .setUri(uri)
+
+    if (title != null) {
+      builder.setMediaMetadata(
+        MediaMetadata.Builder()
+          .setTitle(title)
+          .build()
+      )
+    }
+
+    return builder.build()
   }
 
   private fun createPlaybackUrl(

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -2,33 +2,17 @@ package com.mux.player.media
 
 import android.content.Context
 import androidx.annotation.OptIn
-import androidx.media3.common.C
 import androidx.media3.common.MediaItem
-import androidx.media3.common.PlaybackException
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
-import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
-import androidx.media3.datasource.cache.Cache
-import androidx.media3.datasource.cache.CacheDataSource
-import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
-import androidx.media3.exoplayer.drm.DrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
-import androidx.media3.exoplayer.drm.ExoMediaDrm
-import androidx.media3.exoplayer.drm.FrameworkMediaDrm
-import androidx.media3.exoplayer.drm.MediaDrmCallback
-import androidx.media3.exoplayer.hls.HlsMediaSource
-import androidx.media3.exoplayer.offline.DownloadHelper
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.CmcdConfiguration
 import com.mux.player.internal.Logger
 import com.mux.player.internal.createLogcatLogger
-import com.mux.player.internal.createNoLogger
-import com.mux.player.internal.getPlaybackId
 import com.mux.player.offline.MuxPlayerDownloadStore
-import java.io.IOException
-import java.util.UUID
 
 /**
  * A [MediaSource.Factory] configured to work best with Mux Video.
@@ -79,41 +63,37 @@ class MuxMediaSourceFactory private constructor(
       localConfig != null && playbackID != null
       && localConfig.uri.scheme == MediaItems.URI_SCHEME_MUX_OFFLINE
     ) {
-      createOfflineMediaSource(playbackID)
+      createOfflineMediaSource(item, playbackID)
     } else {
       innerFactory.createMediaSource(item)
     }
   }
 
-  private fun createOfflineMediaSource(playbackId: String): MediaSource {
+  /**
+   * Builds a source for an already-downloaded asset. The download itself isn't looked up here —
+   * we're on the app's thread, and both the index read and opening the download cache block on
+   * disk. [OfflinePlaybackMediaSource] does that work on the playback thread instead.
+   */
+  private fun createOfflineMediaSource(item: MediaItem, playbackId: String): MediaSource {
     val store = MuxPlayerDownloadStore.get(context)
-    val download = store.downloadIndex.getDownload(playbackId)
-    download ?: throw RuntimeException("asset with playbackId $playbackId not downloaded")
-    val drm = download.request.keySetId
-      ?.let { offlinePlaybackDrm(it) } ?: DrmSessionManager.DRM_UNSUPPORTED
 
-    return DownloadHelper.createMediaSource(
-      download.request,
-      cacheOnlyDataSourceFactory(store.downloadCache),
-      drm
+    // Opening the download cache walks the cache directory, so get it started off-thread. The
+    // playback thread will block on it only if it isn't ready by the time playback prepares.
+    // Failures are swallowed on purpose: this is only a warm-up, and an exception escaping a pooled
+    // thread would take the process down. Whatever went wrong recurs on the playback thread below,
+    // where it's reported as a playback error instead.
+    store.ioExecutor.execute { runCatching { store.downloadCache } }
+
+    return OfflinePlaybackMediaSource(
+      mediaItem = item,
+      playbackId = playbackId,
+      // Resolved here rather than on the playback thread on purpose: this is what creates the
+      // DownloadManager, whose constructor captures the calling thread's looper as the one
+      // MuxDownloadManager delivers Listener callbacks on. That needs to be the app's thread.
+      downloadIndex = store.downloadIndex,
+      // Deliberately lazy, so the blocking open happens on the playback thread.
+      downloadCache = { store.downloadCache },
     )
-  }
-
-  private fun offlinePlaybackDrm(keySetId: ByteArray): DrmSessionManager =
-    DefaultDrmSessionManager.Builder()
-      .setUuidAndExoMediaDrmProvider(C.WIDEVINE_UUID, FrameworkMediaDrm.DEFAULT_PROVIDER)
-      .build(FailingDrmCallback()).apply {
-        setMode(
-          DefaultDrmSessionManager.MODE_PLAYBACK,
-          keySetId
-        )
-      }
-
-  private fun cacheOnlyDataSourceFactory(cache: Cache): DataSource.Factory {
-    return CacheDataSource.Factory().apply {
-      setCache(cache)
-      setUpstreamDataSourceFactory(null) // downloaded assets should never need to go online
-    }
   }
 
   init {
@@ -126,22 +106,5 @@ class MuxMediaSourceFactory private constructor(
       drmHttpDataSourceFactory = DefaultHttpDataSource.Factory(),
       logger = logger
     ))
-  }
-}
-
-@OptIn(UnstableApi::class)
-private class FailingDrmCallback : MediaDrmCallback {
-  override fun executeProvisionRequest(
-    uuid: UUID,
-    request: ExoMediaDrm.ProvisionRequest
-  ): MediaDrmCallback.Response {
-    throw IOException("On-disk downloads should never need network")
-  }
-
-  override fun executeKeyRequest(
-    uuid: UUID,
-    request: ExoMediaDrm.KeyRequest
-  ): MediaDrmCallback.Response {
-    throw IOException("On-disk downloads should never need network")
   }
 }

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -79,19 +79,13 @@ class MuxMediaSourceFactory private constructor(
 
     // Opening the download cache walks the cache directory, so get it started off-thread. The
     // playback thread will block on it only if it isn't ready by the time playback prepares.
-    // Failures are swallowed on purpose: this is only a warm-up, and an exception escaping a pooled
-    // thread would take the process down. Whatever went wrong recurs on the playback thread below,
-    // where it's reported as a playback error instead.
     store.ioExecutor.execute { runCatching { store.downloadCache } }
 
     return OfflinePlaybackMediaSource(
       mediaItem = item,
       playbackId = playbackId,
-      // Resolved here rather than on the playback thread on purpose: this is what creates the
-      // DownloadManager, whose constructor captures the calling thread's looper as the one
-      // MuxDownloadManager delivers Listener callbacks on. That needs to be the app's thread.
       downloadIndex = store.downloadIndex,
-      // Deliberately lazy, so the blocking open happens on the playback thread.
+      // lazy, so the blocking open happens in the MediaSource on the playback thread.
       downloadCache = { store.downloadCache },
     )
   }

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -74,7 +74,7 @@ class MuxMediaSourceFactory private constructor(
 
   override fun createMediaSource(item: MediaItem): MediaSource {
     val localConfig = item.localConfiguration
-    val playbackID = item.getPlaybackId()
+    val playbackID = localConfig?.uri?.path
     return if (
       localConfig != null && playbackID != null
       && localConfig.uri.scheme == MediaItems.URI_SCHEME_MUX_OFFLINE

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -71,22 +71,19 @@ class MuxMediaSourceFactory private constructor(
 
   /**
    * Builds a source for an already-downloaded asset. The download itself isn't looked up here —
-   * we're on the app's thread, and both the index read and opening the download cache block on
-   * disk. [OfflinePlaybackMediaSource] does that work on the playback thread instead.
+   * we're on the app's thread, and reading the index hits disk. [OfflinePlaybackMediaSource] does
+   * that on the playback thread instead.
    */
   private fun createOfflineMediaSource(item: MediaItem, playbackId: String): MediaSource {
     val store = MuxPlayerDownloadStore.get(context)
 
-    // Opening the download cache walks the cache directory, so get it started off-thread. The
-    // playback thread will block on it only if it isn't ready by the time playback prepares.
-    store.ioExecutor.execute { runCatching { store.downloadCache } }
-
     return OfflinePlaybackMediaSource(
       mediaItem = item,
       playbackId = playbackId,
+      // Must be resolved on the app's thread: creating the DownloadManager captures the calling
+      // thread's looper as the one MuxDownloadManager delivers Listener callbacks on.
       downloadIndex = store.downloadIndex,
-      // lazy, so the blocking open happens in the MediaSource on the playback thread.
-      downloadCache = { store.downloadCache },
+      downloadCache = store.downloadCache,
     )
   }
 

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -74,7 +74,7 @@ class MuxMediaSourceFactory private constructor(
 
   override fun createMediaSource(item: MediaItem): MediaSource {
     val localConfig = item.localConfiguration
-    val playbackID = localConfig?.uri?.path
+    val playbackID = localConfig?.uri?.lastPathSegment
     return if (
       localConfig != null && playbackID != null
       && localConfig.uri.scheme == MediaItems.URI_SCHEME_MUX_OFFLINE

--- a/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
+++ b/library/src/main/java/com/mux/player/media/MuxMediaSourceFactory.kt
@@ -2,19 +2,33 @@ package com.mux.player.media
 
 import android.content.Context
 import androidx.annotation.OptIn
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.drm.ExoMediaDrm
+import androidx.media3.exoplayer.drm.FrameworkMediaDrm
+import androidx.media3.exoplayer.drm.MediaDrmCallback
+import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.offline.DownloadHelper
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.CmcdConfiguration
 import com.mux.player.internal.Logger
 import com.mux.player.internal.createLogcatLogger
 import com.mux.player.internal.createNoLogger
+import com.mux.player.internal.getPlaybackId
+import com.mux.player.offline.MuxPlayerDownloadStore
+import java.io.IOException
+import java.util.UUID
 
 /**
  * A [MediaSource.Factory] configured to work best with Mux Video.
@@ -40,7 +54,8 @@ class MuxMediaSourceFactory private constructor(
 ) : MediaSource.Factory by innerFactory {
 
   companion object {
-    @JvmSynthetic internal fun create(
+    @JvmSynthetic
+    internal fun create(
       ctx: Context,
       dataSourceFactory: DataSource.Factory,
       innerFactory: DefaultMediaSourceFactory = DefaultMediaSourceFactory(ctx),
@@ -48,12 +63,58 @@ class MuxMediaSourceFactory private constructor(
     ): MuxMediaSourceFactory = MuxMediaSourceFactory(ctx, dataSourceFactory, innerFactory, logger)
   }
 
+  private val context = ctx
+
   @JvmOverloads
   constructor(
     ctx: Context,
     dataSourceFactory: DataSource.Factory,
     innerFactory: DefaultMediaSourceFactory = DefaultMediaSourceFactory(ctx),
-  ) : this (ctx, dataSourceFactory, innerFactory, createLogcatLogger())
+  ) : this(ctx, dataSourceFactory, innerFactory, createLogcatLogger())
+
+  override fun createMediaSource(item: MediaItem): MediaSource {
+    val localConfig = item.localConfiguration
+    val playbackID = item.getPlaybackId()
+    return if (
+      localConfig != null && playbackID != null
+      && localConfig.uri.scheme == MediaItems.URI_SCHEME_MUX_OFFLINE
+    ) {
+      createOfflineMediaSource(playbackID)
+    } else {
+      innerFactory.createMediaSource(item)
+    }
+  }
+
+  private fun createOfflineMediaSource(playbackId: String): MediaSource {
+    val store = MuxPlayerDownloadStore.get(context)
+    val download = store.downloadIndex.getDownload(playbackId)
+    download ?: throw RuntimeException("asset with playbackId $playbackId not downloaded")
+    val drm = download.request.keySetId
+      ?.let { offlinePlaybackDrm(it) } ?: DrmSessionManager.DRM_UNSUPPORTED
+
+    return DownloadHelper.createMediaSource(
+      download.request,
+      cacheOnlyDataSourceFactory(store.downloadCache),
+      drm
+    )
+  }
+
+  private fun offlinePlaybackDrm(keySetId: ByteArray): DrmSessionManager =
+    DefaultDrmSessionManager.Builder()
+      .setUuidAndExoMediaDrmProvider(C.WIDEVINE_UUID, FrameworkMediaDrm.DEFAULT_PROVIDER)
+      .build(FailingDrmCallback()).apply {
+        setMode(
+          DefaultDrmSessionManager.MODE_PLAYBACK,
+          keySetId
+        )
+      }
+
+  private fun cacheOnlyDataSourceFactory(cache: Cache): DataSource.Factory {
+    return CacheDataSource.Factory().apply {
+      setCache(cache)
+      setUpstreamDataSourceFactory(null) // downloaded assets should never need to go online
+    }
+  }
 
   init {
     // basics
@@ -68,4 +129,19 @@ class MuxMediaSourceFactory private constructor(
   }
 }
 
+@OptIn(UnstableApi::class)
+private class FailingDrmCallback : MediaDrmCallback {
+  override fun executeProvisionRequest(
+    uuid: UUID,
+    request: ExoMediaDrm.ProvisionRequest
+  ): MediaDrmCallback.Response {
+    throw IOException("On-disk downloads should never need network")
+  }
 
+  override fun executeKeyRequest(
+    uuid: UUID,
+    request: ExoMediaDrm.KeyRequest
+  ): MediaDrmCallback.Response {
+    throw IOException("On-disk downloads should never need network")
+  }
+}

--- a/library/src/main/java/com/mux/player/media/OfflinePlaybackMediaSource.kt
+++ b/library/src/main/java/com/mux/player/media/OfflinePlaybackMediaSource.kt
@@ -30,19 +30,8 @@ import java.util.UUID
  * actually use on the *playback* thread rather than in
  * [MuxMediaSourceFactory.createMediaSource].
  *
- * The point of the indirection is threading. `createMediaSource` runs on the app's thread — the one
- * that called `Player.setMediaItem` — so it can't read the download index or open the download
- * cache without doing disk I/O on the main thread. [prepareSourceInternal], by contrast, runs on
- * the playback thread, where blocking reads are merely slow instead of an ANR. So this source
- * publishes no [Timeline] of its own: it waits until the player prepares it, resolves the download,
- * and then hands the real source's timeline through.
- *
- * A download that can't be resolved (never downloaded, or an unreadable index) is reported through
- * [maybeThrowSourceInfoRefreshError], which reaches the app as a [PlaybackException] on
- * `Player.Listener.onPlayerError` — the same channel as a failed network manifest. That's deliberate:
- * a download can disappear between building the [MediaItem] and preparing it (the user deletes it,
- * or the app's own cleanup removes it), so this is a recoverable playback failure and not a
- * programming error worth throwing at whoever called `setMediaItem`.
+ * A download that can't be resolved (never downloaded, or an unreadable index) is reported to the
+ *  app as a [PlaybackException]
  *
  * @param mediaItem the `mux_offline` item being played. Used until the child source is prepared.
  * @param playbackId the Mux playback ID, which is also the download's ID.
@@ -76,9 +65,6 @@ internal class OfflinePlaybackMediaSource(
     val child = try {
       resolveDownloadedSource()
     } catch (e: IOException) {
-      // prepareSourceInternal isn't allowed to throw IOException, and throwing anything here would
-      // be reported as an unexpected error with a useless error code. Stash it for
-      // maybeThrowSourceInfoRefreshError, which the player polls while it waits for a timeline.
       resolutionError = e
       return
     }
@@ -111,8 +97,6 @@ internal class OfflinePlaybackMediaSource(
     mediaSource: MediaSource,
     newTimeline: Timeline,
   ) {
-    // Passed through unchanged: one child, one window, so period IDs map 1:1 and createPeriod can
-    // delegate straight to the child.
     refreshSourceInfo(newTimeline)
   }
 
@@ -148,6 +132,7 @@ internal class OfflinePlaybackMediaSource(
  */
 @OptIn(UnstableApi::class)
 private fun offlinePlaybackDrmSessionManager(keySetId: ByteArray): DrmSessionManager =
+  // don't need to use MuxDrmSessionManagerProvider since we're not ever calling out for downloads
   DefaultDrmSessionManager.Builder()
     .setUuidAndExoMediaDrmProvider(C.WIDEVINE_UUID, FrameworkMediaDrm.DEFAULT_PROVIDER)
     .build(FailingDrmCallback())

--- a/library/src/main/java/com/mux/player/media/OfflinePlaybackMediaSource.kt
+++ b/library/src/main/java/com/mux/player/media/OfflinePlaybackMediaSource.kt
@@ -37,15 +37,14 @@ import java.util.UUID
  * @param playbackId the Mux playback ID, which is also the download's ID.
  * @param downloadIndex the index to look the download up in. Resolve this on the app's thread — see
  *   [MuxMediaSourceFactory.createOfflineMediaSource] for why.
- * @param downloadCache the cache holding the downloaded media, opened lazily so the (blocking) open
- *   happens on the playback thread.
+ * @param downloadCache the cache holding the downloaded media.
  */
 @OptIn(UnstableApi::class)
 internal class OfflinePlaybackMediaSource(
   private val mediaItem: MediaItem,
   private val playbackId: String,
   private val downloadIndex: DownloadIndex,
-  private val downloadCache: () -> Cache,
+  private val downloadCache: Cache,
 ) : CompositeMediaSource<Void?>() {
 
   /**
@@ -87,7 +86,7 @@ internal class OfflinePlaybackMediaSource(
 
     return DownloadHelper.createMediaSource(
       download.request,
-      cacheOnlyDataSourceFactory(downloadCache()),
+      cacheOnlyDataSourceFactory(downloadCache),
       drmSessionManager,
     )
   }

--- a/library/src/main/java/com/mux/player/media/OfflinePlaybackMediaSource.kt
+++ b/library/src/main/java/com/mux/player/media/OfflinePlaybackMediaSource.kt
@@ -1,0 +1,178 @@
+package com.mux.player.media
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Timeline
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSourceException
+import androidx.media3.datasource.TransferListener
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
+import androidx.media3.exoplayer.drm.DrmSessionManager
+import androidx.media3.exoplayer.drm.ExoMediaDrm
+import androidx.media3.exoplayer.drm.FrameworkMediaDrm
+import androidx.media3.exoplayer.drm.MediaDrmCallback
+import androidx.media3.exoplayer.offline.DownloadHelper
+import androidx.media3.exoplayer.offline.DownloadIndex
+import androidx.media3.exoplayer.source.CompositeMediaSource
+import androidx.media3.exoplayer.source.MediaPeriod
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.upstream.Allocator
+import java.io.IOException
+import java.util.UUID
+
+/**
+ * Plays a Mux asset that was downloaded for offline playback, resolving which [MediaSource] to
+ * actually use on the *playback* thread rather than in
+ * [MuxMediaSourceFactory.createMediaSource].
+ *
+ * The point of the indirection is threading. `createMediaSource` runs on the app's thread — the one
+ * that called `Player.setMediaItem` — so it can't read the download index or open the download
+ * cache without doing disk I/O on the main thread. [prepareSourceInternal], by contrast, runs on
+ * the playback thread, where blocking reads are merely slow instead of an ANR. So this source
+ * publishes no [Timeline] of its own: it waits until the player prepares it, resolves the download,
+ * and then hands the real source's timeline through.
+ *
+ * A download that can't be resolved (never downloaded, or an unreadable index) is reported through
+ * [maybeThrowSourceInfoRefreshError], which reaches the app as a [PlaybackException] on
+ * `Player.Listener.onPlayerError` — the same channel as a failed network manifest. That's deliberate:
+ * a download can disappear between building the [MediaItem] and preparing it (the user deletes it,
+ * or the app's own cleanup removes it), so this is a recoverable playback failure and not a
+ * programming error worth throwing at whoever called `setMediaItem`.
+ *
+ * @param mediaItem the `mux_offline` item being played. Used until the child source is prepared.
+ * @param playbackId the Mux playback ID, which is also the download's ID.
+ * @param downloadIndex the index to look the download up in. Resolve this on the app's thread — see
+ *   [MuxMediaSourceFactory.createOfflineMediaSource] for why.
+ * @param downloadCache the cache holding the downloaded media, opened lazily so the (blocking) open
+ *   happens on the playback thread.
+ */
+@OptIn(UnstableApi::class)
+internal class OfflinePlaybackMediaSource(
+  private val mediaItem: MediaItem,
+  private val playbackId: String,
+  private val downloadIndex: DownloadIndex,
+  private val downloadCache: () -> Cache,
+) : CompositeMediaSource<Void?>() {
+
+  /**
+   * The real source, once resolved. [CompositeMediaSource] keeps its children private, so we hold
+   * onto it for [createPeriod] and [releasePeriod] to delegate to.
+   */
+  private var childSource: MediaSource? = null
+
+  /** Set when the download couldn't be resolved; thrown from [maybeThrowSourceInfoRefreshError]. */
+  private var resolutionError: IOException? = null
+
+  override fun getMediaItem(): MediaItem = mediaItem
+
+  override fun prepareSourceInternal(mediaTransferListener: TransferListener?) {
+    super.prepareSourceInternal(mediaTransferListener)
+
+    val child = try {
+      resolveDownloadedSource()
+    } catch (e: IOException) {
+      // prepareSourceInternal isn't allowed to throw IOException, and throwing anything here would
+      // be reported as an unexpected error with a useless error code. Stash it for
+      // maybeThrowSourceInfoRefreshError, which the player polls while it waits for a timeline.
+      resolutionError = e
+      return
+    }
+
+    childSource = child
+    prepareChildSource(null, child)
+  }
+
+  @Throws(IOException::class)
+  private fun resolveDownloadedSource(): MediaSource {
+    val download = downloadIndex.getDownload(playbackId)
+      ?: throw DataSourceException(
+        "No offline download for Mux playback ID $playbackId",
+        PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND,
+      )
+
+    val drmSessionManager = download.request.keySetId
+      ?.let { offlinePlaybackDrmSessionManager(it) }
+      ?: DrmSessionManager.DRM_UNSUPPORTED
+
+    return DownloadHelper.createMediaSource(
+      download.request,
+      cacheOnlyDataSourceFactory(downloadCache()),
+      drmSessionManager,
+    )
+  }
+
+  override fun onChildSourceInfoRefreshed(
+    childSourceId: Void?,
+    mediaSource: MediaSource,
+    newTimeline: Timeline,
+  ) {
+    // Passed through unchanged: one child, one window, so period IDs map 1:1 and createPeriod can
+    // delegate straight to the child.
+    refreshSourceInfo(newTimeline)
+  }
+
+  override fun createPeriod(
+    id: MediaSource.MediaPeriodId,
+    allocator: Allocator,
+    startPositionUs: Long,
+  ): MediaPeriod =
+    // Only reachable after we published a Timeline, which only happens once the child is prepared.
+    checkNotNull(childSource).createPeriod(id, allocator, startPositionUs)
+
+  override fun releasePeriod(mediaPeriod: MediaPeriod) {
+    checkNotNull(childSource).releasePeriod(mediaPeriod)
+  }
+
+  override fun maybeThrowSourceInfoRefreshError() {
+    // CompositeMediaSource's implementation only loops over children, so without this a failed
+    // resolution would leave the player buffering forever instead of reporting an error.
+    resolutionError?.let { throw it }
+    super.maybeThrowSourceInfoRefreshError()
+  }
+
+  override fun releaseSourceInternal() {
+    super.releaseSourceInternal()
+    childSource = null
+    resolutionError = null
+  }
+}
+
+/**
+ * A [DrmSessionManager] that plays back using the offline license identified by [keySetId], without
+ * going to the network for it.
+ */
+@OptIn(UnstableApi::class)
+private fun offlinePlaybackDrmSessionManager(keySetId: ByteArray): DrmSessionManager =
+  DefaultDrmSessionManager.Builder()
+    .setUuidAndExoMediaDrmProvider(C.WIDEVINE_UUID, FrameworkMediaDrm.DEFAULT_PROVIDER)
+    .build(FailingDrmCallback())
+    .apply { setMode(DefaultDrmSessionManager.MODE_PLAYBACK, keySetId) }
+
+@OptIn(UnstableApi::class)
+private fun cacheOnlyDataSourceFactory(cache: Cache): DataSource.Factory =
+  CacheDataSource.Factory().apply {
+    setCache(cache)
+    setUpstreamDataSourceFactory(null) // downloaded assets should never need to go online
+  }
+
+@OptIn(UnstableApi::class)
+private class FailingDrmCallback : MediaDrmCallback {
+  override fun executeProvisionRequest(
+    uuid: UUID,
+    request: ExoMediaDrm.ProvisionRequest
+  ): MediaDrmCallback.Response {
+    throw IOException("On-disk downloads should never need network")
+  }
+
+  override fun executeKeyRequest(
+    uuid: UUID,
+    request: ExoMediaDrm.KeyRequest
+  ): MediaDrmCallback.Response {
+    throw IOException("On-disk downloads should never need network")
+  }
+}

--- a/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
+++ b/library/src/main/java/com/mux/player/offline/MuxDownloadManager.kt
@@ -17,7 +17,6 @@ import androidx.media3.exoplayer.offline.DownloadIndex
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.media3.exoplayer.scheduler.Requirements
-import com.google.common.collect.ConcurrentHashMultiset
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import com.mux.player.internal.createLogcatLogger
@@ -52,6 +51,11 @@ object MuxDownloadManager {
   private const val TAG = "MuxDownloadManager"
 
   /**
+   * How often in-progress downloads are polled for progress. See [ProgressUpdateHelper].
+   */
+  private const val PROGRESS_POLL_INTERVAL_MS = 1_000L
+
+  /**
    * Observes offline-download progress and lifecycle changes.
    *
    * All callbacks are delivered on the `DownloadManager`'s application looper, which should be the
@@ -83,9 +87,12 @@ object MuxDownloadManager {
 
   private val listeners = CopyOnWriteArraySet<Listener>()
 
-  // Guards installation of our single DownloadManager.Listener onto the store's manager.
+  // Guards installation of our single DownloadManager.Listener onto the store's manager, and of the
+  // poller that goes with it. A non-null poller means we're installed.
   private val installLock = Any()
-  private var installed = false
+
+  @Volatile
+  private var progressUpdateHelper: ProgressUpdateHelper? = null
 
   private val playbackIdsStarting = ConcurrentHashMap<String, DownloadHelper>()
 
@@ -215,18 +222,19 @@ object MuxDownloadManager {
 
   /**
    * Registers [listener] to observe download progress and lifecycle. Callbacks are delivered on the
-   * `DownloadManager`'s application looper (the main thread in normal use). Non-blocking. Remove it
-   * with [removeListener].
+   * `DownloadManager`'s application looper. Non-blocking. Remove it with [removeListener].
    */
   fun addListener(context: Context, listener: Listener) {
     val store = MuxPlayerDownloadStore.get(context.applicationContext)
-    ensureManagerListenerInstalled(store)
+    val poller = ensureManagerListenerInstalled(store)
     listeners.add(listener)
+    poller.syncAsync()
   }
 
   /** Unregisters a [listener] previously added with [addListener]. */
   fun removeListener(listener: Listener) {
     listeners.remove(listener)
+    progressUpdateHelper?.syncAsync()
   }
 
   /** All downloads known to the index, in any state */
@@ -276,16 +284,23 @@ object MuxDownloadManager {
     return submitToIoExecutor(store) { store.downloadIndex.getDownload(playbackId)?.toMuxDownload() }
   }
 
-  private fun ensureManagerListenerInstalled(store: MuxPlayerDownloadStore) {
-    synchronized(installLock) {
-      if (installed) return
+  private fun ensureManagerListenerInstalled(
+    store: MuxPlayerDownloadStore
+  ): ProgressUpdateHelper = synchronized(installLock) {
+    progressUpdateHelper ?: ProgressUpdateHelper(store.downloadManager).also { poller ->
+      progressUpdateHelper = poller
       store.downloadManager.addListener(ManagerListener)
-      installed = true
     }
   }
 
   /** Translates the shared `DownloadManager.Listener` into [Listener] callbacks. */
   private object ManagerListener : DownloadManager.Listener {
+
+    override fun onInitialized(downloadManager: DownloadManager) {
+      // Downloads restored from the index may resume immediately, without a state change
+      progressUpdateHelper?.sync()
+    }
+
     override fun onDownloadChanged(
       downloadManager: DownloadManager,
       download: Download,
@@ -293,11 +308,24 @@ object MuxDownloadManager {
     ) {
       val snapshot = download.toMuxDownload()
       listeners.forEach { it.onDownloadChanged(snapshot, finalException) }
+      progressUpdateHelper?.sync()
     }
 
     override fun onDownloadRemoved(downloadManager: DownloadManager, download: Download) {
       val snapshot = download.toMuxDownload()
       listeners.forEach { it.onDownloadRemoved(snapshot) }
+      progressUpdateHelper?.sync()
+    }
+
+    override fun onDownloadsPausedChanged(
+      downloadManager: DownloadManager,
+      downloadsPaused: Boolean,
+    ) {
+      progressUpdateHelper?.sync()
+    }
+
+    override fun onIdle(downloadManager: DownloadManager) {
+      progressUpdateHelper?.sync()
     }
 
     override fun onWaitingForRequirementsChanged(
@@ -305,7 +333,71 @@ object MuxDownloadManager {
       waitingForRequirements: Boolean,
     ) {
       listeners.forEach { it.onWaitingForRequirementsChanged(waitingForRequirements) }
+      progressUpdateHelper?.sync()
     }
+  }
+
+  /**
+   * Polls in-progress downloads and reports their progress to [listeners].
+   *
+   * Media3's `DownloadManager` only notifies its listeners on state transitions, so progress
+   * between state transitions (ie, progress percentage/byte count updates)
+   *
+   * Call [sync] to automatically start or stop polling based on the state of the DownloadManager.
+   */
+  private class ProgressUpdateHelper(private val downloadManager: DownloadManager) : Runnable {
+
+    private val handler = Handler(downloadManager.applicationLooper)
+
+    /** Bytes last reported, per playback ID, so a stalled download isn't re-reported each tick. */
+    private val lastReportedBytes = HashMap<String, Long>()
+
+    private var polling = false
+
+    /** Starts or stops the loop so that it's running exactly when there's progress to report. */
+    fun sync() {
+      val shouldPoll =
+        listeners.isNotEmpty() && downloadManager.currentDownloads.any(::isInProgress)
+      if (shouldPoll == polling) return
+
+      polling = shouldPoll
+      if (shouldPoll) {
+        handler.postDelayed(this, PROGRESS_POLL_INTERVAL_MS)
+      } else {
+        handler.removeCallbacks(this)
+        lastReportedBytes.clear()
+      }
+    }
+
+    /** [sync], from any thread. */
+    fun syncAsync() {
+      handler.post { sync() }
+    }
+
+    override fun run() {
+      val inProgress = downloadManager.currentDownloads.filter(::isInProgress)
+      // Downloads that left the list since the last tick shouldn't hold onto their old byte count
+      lastReportedBytes.keys.retainAll(inProgress.mapTo(mutableSetOf()) { it.request.id })
+
+      inProgress.forEach { download ->
+        val bytesDownloaded = download.bytesDownloaded
+        if (lastReportedBytes.put(download.request.id, bytesDownloaded) != bytesDownloaded) {
+          val snapshot = download.toMuxDownload()
+          listeners.forEach { it.onDownloadChanged(snapshot, null) }
+        }
+      }
+
+      if (inProgress.isNotEmpty() && listeners.isNotEmpty()) {
+        handler.postDelayed(this, PROGRESS_POLL_INTERVAL_MS)
+      } else {
+        polling = false
+        lastReportedBytes.clear()
+      }
+    }
+
+    /** Whether [download] is one whose progress moves, and so is worth polling. */
+    private fun isInProgress(download: Download): Boolean =
+      download.state == Download.STATE_DOWNLOADING || download.state == Download.STATE_RESTARTING
   }
 
   /**


### PR DESCRIPTION
Adds the playback path for offline downloads. You just create a `MediaItem` using the same `MediaItems` factory class that callers use for other Mux assets.

This `MediaItem` can be added to a `MuxPlayer` to play the downloaded media like normal. Playback IDs or `MuxDownload` instances can be obtained from `MuxDownloadManager`. This design does not allow downloaded assets in the normal playback path, since we don't want to mix the downloaded renditions with streamed ones. This can lead to inconsistent quality and behavior, depending on network performance and connection status

Callers want to manage their own downloads don't have to use these methods. They would have their own `DownloadManager` that creates `MediaSource`s according to their own logic, which may or may not be via a Factory like this. Media3 doesn't require that, but I think this is the cleanest possible approach for callers who don't want to manage their own stuff.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New playback and offline DRM paths depend on download index/cache correctness and threading; changes are scoped to explicit offline items but affect core ExoPlayer media source behavior.
> 
> **Overview**
> Adds an **explicit offline playback path** so apps can play assets from `MuxDownloadManager` without mixing them with streamed renditions.
> 
> **`MediaItems.forMuxDownload`** now builds real `MediaItem`s using the `mux_offline://` scheme (playback ID in the path), with optional title metadata. **`MuxMediaSourceFactory`** detects that scheme and returns **`OfflinePlaybackMediaSource`**, which resolves the download on the playback thread, builds a cache-only `MediaSource` via `DownloadHelper`, and applies offline Widevine playback when a `keySetId` is present. Missing or invalid downloads surface as **`PlaybackException`** instead of buffering indefinitely.
> 
> **`MuxDownloadManager`** also gains a **`ProgressUpdateHelper`** that polls in-progress downloads about once per second and fires `onDownloadChanged` when byte counts move, since Media3 only notifies on state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cadf5dbecf2042084cd8bae59ae4ce102bfb943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->