### PR TITLE
NAT-485: Add example screen for offline downloads/DRM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   alias(libs.plugins.android.application)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -18,6 +19,7 @@ android {
 
   buildFeatures {
     viewBinding = true
+    compose = true
   }
   buildTypes {
     release {
@@ -38,6 +40,17 @@ dependencies {
   implementation(libs.androidx.constraintlayout)
   implementation(libs.androidx.recyclerview)
   implementation(libs.androidx.activity.ktx)
+
+  // Compose, used by the offline-downloads example
+  implementation(platform(libs.androidx.compose.bom))
+  implementation(libs.androidx.compose.ui)
+  implementation(libs.androidx.compose.material3)
+  implementation(libs.androidx.compose.ui.tooling.preview)
+  implementation(libs.androidx.compose.material.icons.core)
+  implementation(libs.androidx.activity.compose)
+  implementation(libs.androidx.lifecycle.viewmodel.compose)
+  implementation(libs.androidx.lifecycle.runtime.compose)
+  debugImplementation(libs.androidx.compose.ui.tooling)
 
   implementation(project(":library"))
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,11 @@
             android:exported="false"
             android:label="Smart Caching Example" />
         <activity
+            android:name=".examples.offline.OfflineDownloadsActivity"
+            android:exported="false"
+            android:label="Offline Downloads Example"
+            android:theme="@style/Theme.MuxVideoMedia3.NoActionBar" />
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.MuxVideoMedia3.NoActionBar">

--- a/app/src/main/java/com/mux/player/media3/MainActivity.kt
+++ b/app/src/main/java/com/mux/player/media3/MainActivity.kt
@@ -19,6 +19,7 @@ import com.mux.player.media3.examples.BasicPlayerActivity
 import com.mux.player.media3.examples.ConfigurablePlayerActivity
 import com.mux.player.media3.examples.SmartCacheActivity
 import com.mux.player.media3.examples.carousel.PlayerCarouselActivity
+import com.mux.player.media3.examples.offline.OfflineDownloadsActivity
 
 class MainActivity : AppCompatActivity() {
 
@@ -72,6 +73,10 @@ class MainActivity : AppCompatActivity() {
     Example(
       title = "Smart Caching",
       destination = Intent(this@MainActivity, SmartCacheActivity::class.java)
+    ),
+    Example(
+      title = "Offline Downloads",
+      destination = Intent(this@MainActivity, OfflineDownloadsActivity::class.java)
     ),
   )
 }

--- a/app/src/main/java/com/mux/player/media3/examples/offline/DownloadableAssets.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/offline/DownloadableAssets.kt
@@ -1,0 +1,72 @@
+package com.mux.player.media3.examples.offline
+
+import androidx.media3.common.MediaItem
+import com.mux.player.media.MediaItems
+import com.mux.player.media3.PlaybackIds
+
+/**
+ * One Mux asset this example knows how to download.
+ *
+ * @param title A human-readable name, shown in the UI. Not used by the download itself.
+ * @param playbackId The Mux playback ID. This is also the download's ID.
+ * @param playbackToken Required for signed playback and DRM. See [MediaItems.fromMuxPlaybackId].
+ * @param drmToken Required for DRM playback. DRM assets need *both* tokens.
+ */
+data class DownloadableAsset(
+  val title: String,
+  val playbackId: String,
+  val playbackToken: String? = null,
+  val drmToken: String? = null,
+) {
+
+  /**
+   * The [MediaItem] to hand to [com.mux.player.offline.MuxDownloadManager.startDownload]. It's an
+   * ordinary Mux MediaItem — the same one you'd use for streaming playback.
+   */
+  fun toMediaItem(): MediaItem = MediaItems.fromMuxPlaybackId(
+    playbackId = playbackId,
+    playbackToken = playbackToken,
+    drmToken = drmToken,
+  )
+}
+
+/**
+ * The assets offered on the 'Select Asset' screen. Compiled in for the sake of the example; a real
+ * app would fetch its catalog from its own backend.
+ */
+object DownloadableAssets {
+
+  val all: List<DownloadableAsset> = listOf(
+    DownloadableAsset(
+      title = "Tears of Steel",
+      playbackId = PlaybackIds.TEARS_OF_STEEL,
+    ),
+    DownloadableAsset(
+      title = "The Making of Big Buck Bunny",
+      playbackId = PlaybackIds.MAKING_OF_BUCK_BUNNY,
+    ),
+    DownloadableAsset(
+      title = "Elephants Dream",
+      playbackId = PlaybackIds.ELEPHANTS_DREAM,
+    ),
+    DownloadableAsset(
+      title = "Mux Marketing Video",
+      playbackId = PlaybackIds.MUX_MARKETING_VIDEO,
+    ),
+    // To download a DRM asset, add both tokens, which your backend generates:
+    // DownloadableAsset(
+    //   title = "My DRM Asset",
+    //   playbackId = "...",
+    //   playbackToken = "...",
+    //   drmToken = "...",
+    // ),
+  )
+
+  /**
+   * The title for [playbackId], or the playback ID itself if it isn't in [all]. Downloads outlive
+   * the catalog they came from (they're on disk between app launches), so the UI can't assume a
+   * download's asset is still listed.
+   */
+  fun titleFor(playbackId: String): String =
+    all.firstOrNull { it.playbackId == playbackId }?.title ?: playbackId
+}

--- a/app/src/main/java/com/mux/player/media3/examples/offline/DownloadsScreen.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/offline/DownloadsScreen.kt
@@ -188,7 +188,7 @@ private fun DownloadListItemStartingPreview() {
       DownloadListItem(
         title = "Elephants Dream",
         state = MuxDownload.State.STARTING,
-        percentDownloaded = C.PERCENTAGE_UNSET.toFloat(),
+        percentDownloaded = (-1).toFloat(),
         onClick = {},
         onRemoveClick = {},
       )

--- a/app/src/main/java/com/mux/player/media3/examples/offline/DownloadsScreen.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/offline/DownloadsScreen.kt
@@ -1,0 +1,239 @@
+package com.mux.player.media3.examples.offline
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.C
+import com.mux.player.offline.MuxDownload
+
+/**
+ * Screen 1: everything Mux Player has downloaded or is downloading, plus a row for adding more.
+ *
+ * Stateless — the caller supplies [downloads] and handles all of the callbacks. Tapping a completed
+ * download plays it; tapping anything else does nothing (there's nothing to play yet).
+ */
+@Composable
+fun DownloadsScreen(
+  downloads: List<MuxDownload>,
+  onAddDownloadClick: () -> Unit,
+  onPlayDownload: (MuxDownload) -> Unit,
+  onRemoveDownload: (MuxDownload) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Scaffold(
+    modifier = modifier.fillMaxSize(),
+    topBar = { DownloadsTopBar() },
+  ) { insets ->
+    LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      contentPadding = insets,
+    ) {
+      item(key = "add-download") {
+        AddDownloadListItem(onClick = onAddDownloadClick)
+        HorizontalDivider()
+      }
+
+      items(downloads, key = { it.playbackId }) { download ->
+        DownloadListItem(
+          title = DownloadableAssets.titleFor(download.playbackId),
+          state = download.state,
+          percentDownloaded = download.percentDownloaded,
+          onClick = { onPlayDownload(download) },
+          onRemoveClick = { onRemoveDownload(download) },
+        )
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DownloadsTopBar() {
+  TopAppBar(title = { Text("Offline Downloads") })
+}
+
+/**
+ * One download. Simplified for now: a title, its state, and a progress bar while it's in flight.
+ *
+ * Takes the download's fields individually rather than a [MuxDownload] so it can be previewed —
+ * [MuxDownload]'s constructor is internal to the SDK, since only the SDK ever creates one.
+ *
+ * @param percentDownloaded `0.0..100.0`, or [C.PERCENTAGE_UNSET] if not yet known.
+ * @param onClick Invoked only when this download is [MuxDownload.State.COMPLETED], i.e. playable.
+ */
+@Composable
+fun DownloadListItem(
+  title: String,
+  state: MuxDownload.State,
+  percentDownloaded: Float,
+  onClick: () -> Unit,
+  onRemoveClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val playable = state == MuxDownload.State.COMPLETED
+
+  ListItem(
+    modifier = modifier.clickable(enabled = playable, onClick = onClick),
+    headlineContent = {
+      Text(text = title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    },
+    supportingContent = {
+      Column {
+        Text(text = state.label(percentDownloaded))
+        if (state.isInFlight()) {
+          DownloadProgressBar(percentDownloaded)
+        }
+      }
+    },
+    trailingContent = {
+      TextButton(onClick = onRemoveClick) {
+        Text("Delete")
+      }
+    },
+  )
+}
+
+/** The row that opens the 'Select Asset' screen. */
+@Composable
+fun AddDownloadListItem(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ListItem(
+    modifier = modifier.clickable(onClick = onClick),
+    headlineContent = { Text("+  Download an asset") },
+  )
+}
+
+@Composable
+private fun DownloadProgressBar(percentDownloaded: Float, modifier: Modifier = Modifier) {
+  val barModifier = modifier
+    .fillMaxWidth()
+    .padding(top = 4.dp)
+
+  // The DownloadManager doesn't know the content length until the download actually starts, so
+  // there's a window where the only honest thing to show is an indeterminate bar.
+  if (percentDownloaded == C.PERCENTAGE_UNSET.toFloat()) {
+    LinearProgressIndicator(modifier = barModifier)
+  } else {
+    LinearProgressIndicator(
+      progress = { percentDownloaded / 100f },
+      modifier = barModifier,
+    )
+  }
+}
+
+/** True while the download is working toward completion, so progress is worth showing. */
+private fun MuxDownload.State.isInFlight(): Boolean = when (this) {
+  MuxDownload.State.STARTING,
+  MuxDownload.State.QUEUED,
+  MuxDownload.State.DOWNLOADING,
+  MuxDownload.State.REMOVING -> true
+
+  MuxDownload.State.COMPLETED,
+  MuxDownload.State.FAILED,
+  MuxDownload.State.STOPPED -> false
+}
+
+private fun MuxDownload.State.label(percentDownloaded: Float): String = when (this) {
+  MuxDownload.State.STARTING -> "Preparing…"
+  MuxDownload.State.QUEUED -> "Queued"
+  MuxDownload.State.DOWNLOADING -> "Downloading ${percentDownloaded.toInt()}%"
+  MuxDownload.State.COMPLETED -> "Ready to play offline"
+  MuxDownload.State.FAILED -> "Failed"
+  MuxDownload.State.REMOVING -> "Removing…"
+  MuxDownload.State.STOPPED -> "Paused"
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DownloadListItemDownloadingPreview() {
+  MaterialTheme {
+    Surface {
+      DownloadListItem(
+        title = "Tears of Steel",
+        state = MuxDownload.State.DOWNLOADING,
+        percentDownloaded = 42f,
+        onClick = {},
+        onRemoveClick = {},
+      )
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DownloadListItemStartingPreview() {
+  MaterialTheme {
+    Surface {
+      DownloadListItem(
+        title = "Elephants Dream",
+        state = MuxDownload.State.STARTING,
+        percentDownloaded = C.PERCENTAGE_UNSET.toFloat(),
+        onClick = {},
+        onRemoveClick = {},
+      )
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DownloadListItemCompletedPreview() {
+  MaterialTheme {
+    Surface {
+      DownloadListItem(
+        title = "The Making of Big Buck Bunny",
+        state = MuxDownload.State.COMPLETED,
+        percentDownloaded = 100f,
+        onClick = {},
+        onRemoveClick = {},
+      )
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DownloadListItemFailedPreview() {
+  MaterialTheme {
+    Surface {
+      DownloadListItem(
+        title = "Mux Marketing Video",
+        state = MuxDownload.State.FAILED,
+        percentDownloaded = 12f,
+        onClick = {},
+        onRemoveClick = {},
+      )
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddDownloadListItemPreview() {
+  MaterialTheme {
+    Surface {
+      AddDownloadListItem(onClick = {})
+    }
+  }
+}

--- a/app/src/main/java/com/mux/player/media3/examples/offline/OfflineDownloadsActivity.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/offline/OfflineDownloadsActivity.kt
@@ -1,0 +1,102 @@
+package com.mux.player.media3.examples.offline
+
+import android.Manifest
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+/**
+ * An example of Mux Player's offline downloads: pick an asset, watch it download, then play it back
+ * from disk.
+ *
+ * The three screens are:
+ * - [DownloadsScreen], the downloads you have (in progress and complete), plus a row to add more
+ * - [SelectAssetScreen], the assets available to download
+ * - [OfflinePlayerScreen], playback of a completed download
+ *
+ * Downloads run in `MuxDownloadService`, not here — see this app's `AndroidManifest.xml` for the
+ * `<service>` and permissions an app needs in order to use downloads at all.
+ */
+class OfflineDownloadsActivity : AppCompatActivity() {
+
+  private val requestNotificationPermission =
+    registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* advisory only */ }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
+
+    // Downloads run in a foreground service that posts a progress notification. Without this
+    // permission the downloads still run; the user just doesn't see them.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    setContent {
+      MaterialTheme {
+        OfflineDownloadsExample()
+      }
+    }
+  }
+}
+
+/**
+ * Hosts the example's three screens and is the only place that talks to
+ * [OfflineDownloadsViewModel]. The screens below it are stateless: they take data and emit events.
+ */
+@Composable
+fun OfflineDownloadsExample(viewModel: OfflineDownloadsViewModel = viewModel()) {
+  val downloads by viewModel.downloads.collectAsStateWithLifecycle()
+  var screen: Screen by remember { mutableStateOf(Screen.Downloads) }
+
+  when (val current = screen) {
+    Screen.Downloads -> DownloadsScreen(
+      downloads = downloads,
+      onAddDownloadClick = { screen = Screen.SelectAsset },
+      onPlayDownload = { screen = Screen.Player(it.playbackId) },
+      onRemoveDownload = { viewModel.removeDownload(it.playbackId) },
+    )
+
+    Screen.SelectAsset -> SelectAssetScreen(
+      assets = DownloadableAssets.all,
+      onAssetClick = { asset ->
+        viewModel.startDownload(asset)
+        // Progress shows up on the downloads screen, so go watch it there.
+        screen = Screen.Downloads
+      },
+      onBackClick = { screen = Screen.Downloads },
+    )
+
+    is Screen.Player -> OfflinePlayerScreen(
+      playbackId = current.playbackId,
+      onBackClick = { screen = Screen.Downloads },
+    )
+  }
+
+  // Downloads is the root screen; anywhere else, back returns to it instead of finishing.
+  BackHandler(enabled = screen != Screen.Downloads) {
+    screen = Screen.Downloads
+  }
+}
+
+/**
+ * Which screen is showing. Deliberately hand-rolled rather than using a navigation library — this
+ * example is about downloads, and three screens don't need one.
+ */
+private sealed interface Screen {
+  data object Downloads : Screen
+  data object SelectAsset : Screen
+  data class Player(val playbackId: String) : Screen
+}

--- a/app/src/main/java/com/mux/player/media3/examples/offline/OfflineDownloadsViewModel.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/offline/OfflineDownloadsViewModel.kt
@@ -1,0 +1,102 @@
+package com.mux.player.media3.examples.offline
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.mux.player.offline.MuxDownload
+import com.mux.player.offline.MuxDownloadManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the list of Mux offline downloads and nothing else. The screens in this example are
+ * stateless: they take [downloads] plus callbacks, and the composable that hosts them
+ * ([OfflineDownloadsExample]) is the only thing that talks to this ViewModel.
+ *
+ * Two sources feed [downloads]:
+ * 1. [MuxDownloadManager.allDownloads], read once, for downloads that already existed on disk when
+ *    this screen opened (downloads survive app restarts).
+ * 2. [MuxDownloadManager.Listener], for live progress and state changes from here on.
+ */
+class OfflineDownloadsViewModel(private val app: Application) : AndroidViewModel(app) {
+
+  /**
+   * Every download known to Mux Player, in any state — in-progress and completed alike. Ordered
+   * oldest-first, with newly started downloads appended.
+   */
+  val downloads: StateFlow<List<MuxDownload>> get() = _downloads.asStateFlow()
+
+  private val _downloads = MutableStateFlow<List<MuxDownload>>(emptyList())
+
+  private val downloadListener = object : MuxDownloadManager.Listener {
+    override fun onDownloadChanged(download: MuxDownload, error: Throwable?) {
+      if (error != null) {
+        Log.e(TAG, "Download failed for playback ID ${download.playbackId}", error)
+      }
+      upsert(download)
+    }
+
+    override fun onDownloadRemoved(download: MuxDownload) {
+      _downloads.update { downloads ->
+        downloads.filterNot { it.playbackId == download.playbackId }
+      }
+    }
+
+    override fun onWaitingForRequirementsChanged(waitingForRequirements: Boolean) {
+      // Downloads are stalled only because the DownloadManager's Requirements aren't met (by
+      // default, that means no network). A real app might surface this in its UI.
+      Log.i(TAG, "Waiting for download requirements: $waitingForRequirements")
+    }
+  }
+
+  init {
+    // Listen before reading the index, so a change that lands mid-read isn't missed.
+    MuxDownloadManager.addListener(app, downloadListener)
+
+    viewModelScope.launch {
+      val alreadyOnDisk = MuxDownloadManager.allDownloads(app)
+      _downloads.update { live ->
+        // Anything the listener already told us about is fresher than the index read, so it wins.
+        val livePlaybackIds = live.mapTo(mutableSetOf()) { it.playbackId }
+        alreadyOnDisk.filterNot { it.playbackId in livePlaybackIds } + live
+      }
+    }
+  }
+
+  override fun onCleared() {
+    MuxDownloadManager.removeListener(downloadListener)
+    super.onCleared()
+  }
+
+  /**
+   * Starts downloading [asset]. Progress arrives via [downloads]; the download continues in
+   * [com.mux.player.offline.MuxDownloadService] even if this screen goes away.
+   */
+  fun startDownload(asset: DownloadableAsset) {
+    MuxDownloadManager.startDownload(app, asset.toMediaItem())
+  }
+
+  /** Deletes the download for [playbackId], including its media and any offline DRM license. */
+  fun removeDownload(playbackId: String) {
+    MuxDownloadManager.removeDownload(app, playbackId)
+  }
+
+  private fun upsert(download: MuxDownload) {
+    _downloads.update { downloads ->
+      val index = downloads.indexOfFirst { it.playbackId == download.playbackId }
+      if (index < 0) {
+        downloads + download
+      } else {
+        downloads.toMutableList().apply { this[index] = download }
+      }
+    }
+  }
+
+  private companion object {
+    const val TAG = "OfflineDownloadsVM"
+  }
+}

--- a/app/src/main/java/com/mux/player/media3/examples/offline/OfflinePlayerScreen.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/offline/OfflinePlayerScreen.kt
@@ -1,0 +1,101 @@
+package com.mux.player.media3.examples.offline
+
+import android.util.Log
+import android.widget.Toast
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.PlayerView
+import com.mux.player.MuxPlayer
+import com.mux.player.media.MediaItems
+
+/**
+ * Screen 3: plays a completed download, from disk.
+ *
+ * The only offline-specific part is the [MediaItem][androidx.media3.common.MediaItem]:
+ * [MediaItems.forMuxDownload] points at the downloaded copy instead of the network, and
+ * [MuxPlayer]'s default `MediaSource.Factory` knows how to read it. Nothing else about the player
+ * setup changes, and no `MuxDownloadManager` lookup is needed — which is why this screen doesn't
+ * touch [OfflineDownloadsViewModel].
+ *
+ * The player is owned by the composition (created here, released on the way out) rather than by a
+ * ViewModel, so it can't outlive the screen.
+ */
+@Composable
+fun OfflinePlayerScreen(
+  playbackId: String,
+  onBackClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val context = LocalContext.current
+  val playerView = remember { PlayerView(context) }
+
+  DisposableEffect(playbackId) {
+    val player = MuxPlayer.Builder(context)
+      .enableLogcat(true)
+      .build()
+
+    player.addListener(object : Player.Listener {
+      override fun onPlayerError(error: PlaybackException) {
+        Log.e(TAG, "Offline playback error for $playbackId", error)
+        Toast.makeText(context, "Playback error: ${error.localizedMessage}", Toast.LENGTH_LONG)
+          .show()
+      }
+    })
+
+    player.setMediaItem(MediaItems.forMuxDownload(playbackId))
+    player.prepare()
+    player.playWhenReady = true
+    playerView.player = player
+
+    onDispose {
+      playerView.player = null
+      player.release()
+    }
+  }
+
+  Scaffold(
+    modifier = modifier.fillMaxSize(),
+    topBar = { OfflinePlayerTopBar(playbackId = playbackId, onBackClick = onBackClick) },
+  ) { insets ->
+    Box(modifier = Modifier.fillMaxSize().padding(insets)) {
+      AndroidView(
+        factory = { playerView },
+        modifier = Modifier.fillMaxSize(),
+      )
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun OfflinePlayerTopBar(playbackId: String, onBackClick: () -> Unit) {
+  TopAppBar(
+    title = { Text(DownloadableAssets.titleFor(playbackId)) },
+    navigationIcon = {
+      IconButton(onClick = onBackClick) {
+        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+      }
+    },
+  )
+}
+
+private const val TAG = "OfflinePlayerScreen"

--- a/app/src/main/java/com/mux/player/media3/examples/offline/SelectAssetScreen.kt
+++ b/app/src/main/java/com/mux/player/media3/examples/offline/SelectAssetScreen.kt
@@ -1,0 +1,94 @@
+package com.mux.player.media3.examples.offline
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Screen 2: the assets available to download. Tapping one starts its download and returns to
+ * [DownloadsScreen], where its progress shows up.
+ *
+ * Stateless — the caller supplies [assets] and handles the callbacks.
+ */
+@Composable
+fun SelectAssetScreen(
+  assets: List<DownloadableAsset>,
+  onAssetClick: (DownloadableAsset) -> Unit,
+  onBackClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Scaffold(
+    modifier = modifier.fillMaxSize(),
+    topBar = { SelectAssetTopBar(onBackClick = onBackClick) },
+  ) { insets ->
+    LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      contentPadding = insets,
+    ) {
+      items(assets, key = { it.playbackId }) { asset ->
+        AssetListItem(
+          title = asset.title,
+          playbackId = asset.playbackId,
+          onClick = { onAssetClick(asset) },
+        )
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SelectAssetTopBar(onBackClick: () -> Unit) {
+  TopAppBar(
+    title = { Text("Select Asset") },
+    navigationIcon = {
+      TextButton(onClick = onBackClick) { Text("Back") }
+    },
+  )
+}
+
+/** One downloadable asset. Simplified for now: its title over its playback ID. */
+@Composable
+fun AssetListItem(
+  title: String,
+  playbackId: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  ListItem(
+    modifier = modifier.clickable(onClick = onClick),
+    headlineContent = {
+      Text(text = title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    },
+    supportingContent = {
+      Text(text = playbackId, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    },
+  )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AssetListItemPreview() {
+  MaterialTheme {
+    Surface {
+      AssetListItem(
+        title = "Tears of Steel",
+        playbackId = "rojBpoQ8QkSRwvKMsS8FUuCbaANJDN02HRWqFXNBtjH00",
+        onClick = {},
+      )
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,10 @@ recyclerview = "1.3.2"
 activityKtx = "1.9.2"
 navigation = "2.5.3"
 
+composeBom = "2026.06.01"
+activityCompose = "1.13.0"
+lifecycleCompose = "2.11.0"
+
 media3 = "1.10.1"
 muxData = "1.12.0"
 coroutines = "1.11.0"
@@ -36,6 +40,17 @@ androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigation" }
 androidx-navigation-ui = { module = "androidx.navigation:navigation-ui", version.ref = "navigation" }
+
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+# Frozen at 1.7.8 (deprecated in Compose 1.7.0) but still pinned by the Compose BOM
+androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleCompose" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleCompose" }
 
 media3-common = { module = "androidx.media3:media3-common", version.ref = "media3" }
 media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
@@ -62,4 +77,5 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 mux-android-distribution = { id = "com.mux.gradle.android.mux-android-distribution", version.ref = "muxAndroidDistribution" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to the sample app and Gradle/Compose wiring; they demonstrate existing SDK offline APIs without altering library behavior.
> 
> **Overview**
> Adds a new **Offline Downloads** sample to the Media3 demo app, wired from `MainActivity` and registered as `OfflineDownloadsActivity`.
> 
> The sample app gains **Jetpack Compose** (BOM, Material3, lifecycle/activity-compose, kotlin-compose plugin) solely to host this flow. Users browse existing/in-progress downloads, pick from a hard-coded Mux asset catalog (`DownloadableAssets`), start/remove jobs via `MuxDownloadManager`, and play completed items with `MediaItems.forMuxDownload` in `MuxPlayer`. `OfflineDownloadsViewModel` merges `allDownloads` with listener updates; the activity requests notification permission on API 33+ for foreground download progress.
> 
> Comments in `DownloadableAssets` show how to add signed/DRM assets with tokens; the shipped list uses public playback IDs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7079ccf5cd89a9817c3bc8aa2788e7fd06217479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->