### PR TITLE
chore: update media3 to 1.11.0 and Mux Data to 1.13.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ composeBom = "2026.06.01"
 activityCompose = "1.13.0"
 lifecycleCompose = "2.11.0"
 
-media3 = "1.10.1"
-muxData = "1.12.0"
+media3 = "1.11.0"
+muxData = "1.13.2"
 coroutines = "1.11.0"
 
 junit = "4.13.2"
@@ -57,7 +57,7 @@ media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = 
 media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "media3" }
 media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
-mux-data-media3 = { module = "com.mux.stats.sdk.muxstats:data-media3-at_1_10", version.ref = "muxData" }
+mux-data-media3 = { module = "com.mux.stats.sdk.muxstats:data-media3-at_1_11", version.ref = "muxData" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 

--- a/library/src/test/java/com/mux/player/offline/MuxHlsDownloadCallbackTests.kt
+++ b/library/src/test/java/com/mux/player/offline/MuxHlsDownloadCallbackTests.kt
@@ -269,6 +269,7 @@ class MuxHlsDownloadCallbackTests : AbsRobolectricTest() {
       /* hasIndependentSegments = */ false,
       /* variableDefinitions = */ emptyMap(),
       /* sessionKeyDrmInitData = */ emptyList(),
+      /* contentSteeringInfo = */ null,
     )
 
   private fun directExecutor() = Executor { it.run() }


### PR DESCRIPTION
## What

Updates both dependencies to their latest stable releases:

| | Before | After |
|---|---|---|
| media3 | 1.10.1 | **1.11.0** |
| Mux Data | 1.12.0 | **1.13.2** |

The Mux Data artifact coordinate is pinned to the media3 minor version, so `data-media3-at_1_10` becomes `data-media3-at_1_11`. Mux Data 1.13.2 exists specifically to add media3 1.11.x support.

## One code change was needed

media3 1.11.0 [adds HLS Content Steering and Pathway Cloning](https://github.com/androidx/media/issues/1689), which appended a 13th nullable `ContentSteeringInfo` parameter to the `HlsMultivariantPlaylist` constructor. That broke one test fixture in `MuxHlsDownloadCallbackTests`, which now passes `null`.

No main-source changes: our offline code only ever *reads* multivariant playlists (`CapturingHlsPlaylistParserFactory`, and `MuxHlsDownloadCallback` building `StreamKey`s) and never constructs them.

## Changelog review

I checked both changelogs for anything affecting the offline download / DRM work that just landed in #106. Nothing does:

- **media3 1.11.0** — the only download-related change is a fix (resolve HLS variables in media playlists fetched for download). Content Steering is purely additive.
- **Mux Data 1.13.x** — `audiotrackchange` events, play/pause fixes for non-ExoPlayer `Player`s, and a generic-bounds tightening on `monitorWithMuxData` (`*` -> `Player`) that compiles clean here.

## Testing

- All 27 library unit tests pass, including the offline/DRM suites from #106
- `assembleDebug` succeeds for all modules, plus the `automatedtests` instrumentation APK
- Verified the resolved graph is actually `androidx.media3:*:1.11.0` and `data-media3-at_1_11:1.13.2`

## Note for release notes

The Mux Data artifact coordinate change is consumer-visible for anyone who depends on Mux Data directly alongside this SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bumps with a single test-only constructor fix; main offline/DRM paths do not construct multivariant playlists.
> 
> **Overview**
> Bumps **androidx.media3** from 1.10.1 to **1.11.0** and **Mux Data** from 1.12.0 to **1.13.2**, and switches the Mux artifact from `data-media3-at_1_10` to **`data-media3-at_1_11`** so it matches the Media3 minor version.
> 
> The only source change is in **`MuxHlsDownloadCallbackTests`**: the `HlsMultivariantPlaylist` test fixture now passes **`contentSteeringInfo = null`** for Media3 1.11’s new constructor parameter (HLS Content Steering). Production offline/HLS code is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b51cbbea13db858e8c18eb6fb6b13c888970b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->